### PR TITLE
Pylbo: support for matplotlib 3.4

### DIFF
--- a/pylbo_wrapper.py
+++ b/pylbo_wrapper.py
@@ -5,22 +5,23 @@ import pylbo
 
 def _main():
     parser = ArgumentParser()
-    parser.add_argument('-i', '--datfile', dest='datfile')
+    parser.add_argument("-i", "--datfile", dest="datfile")
     args = parser.parse_args()
     datfile = args.datfile
 
     if datfile is None:
-        datfile = Path('output/datfile.dat').resolve()
+        datfile = Path("output/datfile.dat").resolve()
         if not datfile.is_file():
             raise FileNotFoundError(datfile)
 
     ds = pylbo.load(datfile)
-    p2 = pylbo.plot_equilibrium(ds)
+    pylbo.plot_equilibrium(ds)
     p = pylbo.plot_spectrum(ds)
     p.add_continua()
-    p.add_eigenfunctions()
-    p.showall()
+    if ds.header["eigenfuncs_written"]:
+        p.add_eigenfunctions()
+    p.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     _main()


### PR DESCRIPTION
Matplotlib 3.4 introduced some deprecations and behaviour changes which affected Pylbo. Most notably, when adding eigenfunctions we change the axes geometry to account for the extra figure and this is deprecated as of now ([see here](https://matplotlib.org/stable/api/api_changes.html#subplot-related-attributes-and-methods)).

Also, Pylbo used to allow for the closing and reshowing of figures by reconstructing the figure managers. Since MPL 3.4 [this changed](https://matplotlib.org/stable/api/api_changes.html#canvas-s-callback-registry-now-stored-on-figure):

> **Canvas's callback registry now stored on Figure**
> 
> The canonical location of the CallbackRegistry used to handle Figure/Canvas events has been moved from the Canvas to the Figure. This change should be transparent to almost all users, however if you are swapping switching the Figure out from on top of a Canvas or visa versa you may see a change in behavior.

This disables panning and zooming (see also [this issue](https://github.com/matplotlib/matplotlib/issues/20159)) in 3.4, and it appears reconstruction is not possible anymore since the callbacks are no longer transferred to the new figure. I disabled this functionality, now calling `p.show()` or `p.showall()` just show all figures by default, both are kept for backwards compatibility with code.

This PR fixes #67.

