### PR TITLE
Bugfix/b01 v01 output

### DIFF
--- a/post_processing/pylbo/data_containers.py
+++ b/post_processing/pylbo/data_containers.py
@@ -322,8 +322,7 @@ class LegolasDataSet(LegolasDataContainer):
             Array with the Alfvén speed at every grid point,
             or a float corresponding to the value of `which_values` if provided.
         """
-        B0 = np.sqrt(self.equilibria["B02"] ** 2 + self.equilibria["B03"] ** 2)
-        cA = B0 / np.sqrt(self.equilibria["rho0"])
+        cA = self.equilibria["B0"] / np.sqrt(self.equilibria["rho0"])
         return self._get_values(cA, which_values)
 
     def get_tube_speed(self, which_values=None):

--- a/post_processing/pylbo/visualisation/continua.py
+++ b/post_processing/pylbo/visualisation/continua.py
@@ -23,7 +23,7 @@ def calculate_continua(ds):
     rho = ds.equilibria["rho0"]
     B02 = ds.equilibria["B02"]
     B03 = ds.equilibria["B03"]
-    B0 = np.sqrt(B02 ** 2 + B03 ** 2)
+    B0 = ds.equilibria["B0"]
     v02 = ds.equilibria["v02"]
     v03 = ds.equilibria["v03"]
     T = ds.equilibria["T0"]

--- a/src/dataIO/datfile_changes.txt
+++ b/src/dataIO/datfile_changes.txt
@@ -20,3 +20,7 @@ No update of the pylbo reader needed
 === version 1.0.4 --> 1.0.5 ===
 1) added cte_B01 to param_names between cte_T0 and cte_B02
 2) added cte_B01 to the data between cte_T0 and cte_B02
+
+=== version 1.0.5 --> 1.1.1 === (PR #71)
+1) added B01, ddT0, v01, dv01, ddv01 to equil_names
+2) added B01, ddT0, v01, dv01, ddv01 to equilibrium data

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -82,7 +82,8 @@ contains
     !> the B-matrix
     real(dp), intent(in)          :: matrix_B(:, :)
 
-    character(len=str_len_arr)    :: param_names(33), equil_names(27)
+    real(dp)  :: b01_array(size(B_field % B02))
+    character(len=str_len_arr)    :: param_names(33), equil_names(32)
     character(len=2*str_len_arr)  :: unit_names(11)
     integer                       :: i, j, nonzero_A_values, nonzero_B_values
 
@@ -95,9 +96,9 @@ contains
     equil_names = [ &
       character(len=str_len_arr) :: &
         "rho0", "drho0", &
-        "T0", "dT0", &
-        "B02", "B03", "dB02", "dB03", "ddB02", "ddB03", "B0", &
-        "v02", "v03", "dv02", "dv03", "ddv02", "ddv03", &
+        "T0", "dT0", "ddT0", &
+        "B01", "B02", "B03", "dB02", "dB03", "ddB02", "ddB03", "B0", &
+        "v01", "v02", "v03", "dv01", "dv02", "dv03", "ddv01", "ddv02", "ddv03", &
         "dLdT", "dLdrho", &
         "kappa_para", "kappa_perp", &
         "eta", "detadT", "detadr", &
@@ -109,6 +110,8 @@ contains
       "unit_velocity", "unit_temperature", "unit_pressure", "unit_magneticfield", &
       "unit_numberdensity", "unit_lambdaT", "unit_conduction", "unit_resistivity" &
     ]
+    ! fill B01 array
+    b01_array = B_field % B01
 
     call make_filename(trim(basename_datfile) // ".dat", datfile_name)
     call open_file(dat_fh, datfile_name)
@@ -134,13 +137,13 @@ contains
     write(dat_fh) size(eigenvalues), eigenvalues, grid, grid_gauss
     write(dat_fh) &
       rho_field % rho0, rho_field % d_rho0_dr, &
-      T_field % T0, T_field % d_T0_dr, &
-      B_field % B02, B_field % B03, &
+      T_field % T0, T_field % d_T0_dr, T_field % dd_T0_dr, &
+      b01_array, B_field % B02, B_field % B03, &
       B_field % d_B02_dr, B_field % d_B03_dr, &
       eta_field % dd_B02_dr, eta_field % dd_B03_dr, B_field % B0, &
-      v_field % v02, v_field % v03, &
-      v_field % d_v02_dr, v_field % d_v03_dr, &
-      v_field % dd_v02_dr, v_field % dd_v03_dr, &
+      v_field % v01, v_field % v02, v_field % v03, &
+      v_field % d_v01_dr, v_field % d_v02_dr, v_field % d_v03_dr, &
+      v_field % dd_v01_dr, v_field % dd_v02_dr, v_field % dd_v03_dr, &
       rc_field % d_L_dT, rc_field % d_L_drho, &
       kappa_field % kappa_para, kappa_field % kappa_perp, &
       eta_field % eta, eta_field % d_eta_dT, eta_field % d_eta_dr, &


### PR DESCRIPTION
When merging #66 the `v01` components, `ddT0` components and `B01` components were not accounted for in either the datfile output or when using the total magnetic field with Pylbo. This PR fixes that, `B01` is also added as an array to the equilibrium quantities (even though it's a constant) such that Pylbo can pick it up when reading the datfile header (and automatically include it in eg. profile plots).
