### PR TITLE
Add mean molecular weight support to units

### DIFF
--- a/post_processing/pylbo/automation/defaults.py
+++ b/post_processing/pylbo/automation/defaults.py
@@ -63,6 +63,7 @@ namelist_items = {
         ("unit_temperature", (int, np.integer, float)),
         ("unit_magneticfield", (int, np.integer, float)),
         ("unit_length", (int, np.integer, float)),
+        ("mean_molecular_weight", (int, np.integer, float)),
     ],
     "solvelist": [
         ("solver", str),

--- a/post_processing/pylbo/utilities/datfile_utils.py
+++ b/post_processing/pylbo/utilities/datfile_utils.py
@@ -170,6 +170,9 @@ def get_header(istream):
     unit_values = struct.unpack(fmt, istream.read(struct.calcsize(fmt)))
     for name, value in zip(unit_names, unit_values):
         units[name] = value
+    # mean molecular weight is added in 1.1.2, before this it defaults to 1
+    if "mean_molecular_weight" not in unit_names:
+        units["mean_molecular_weight"] = 1.0
     h["units"] = units
 
     # @Devnote Niels: do not read in data here but simply determine the data offset

--- a/src/dataIO/datfile_changes.txt
+++ b/src/dataIO/datfile_changes.txt
@@ -24,3 +24,8 @@ No update of the pylbo reader needed
 === version 1.0.5 --> 1.1.1 === (PR #71)
 1) added B01, ddT0, v01, dv01, ddv01 to equil_names
 2) added B01, ddT0, v01, dv01, ddv01 to equilibrium data
+
+=== version 1.1.1 --> 1.1.2 ===
+1) added mean_molecular_weight to unit_names
+2) added mean molecular weight to units
+added this in a backwards compatible way to the pylbo reader

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -89,7 +89,7 @@ contains
 
     real(dp)  :: b01_array(size(B_field % B02))
     character(len=str_len_arr)    :: param_names(33), equil_names(32)
-    character(len=2*str_len_arr)  :: unit_names(11)
+    character(len=2*str_len_arr)  :: unit_names(12)
     integer                       :: i, j, nonzero_A_values, nonzero_B_values
 
     param_names = [ &
@@ -113,7 +113,8 @@ contains
     unit_names = [ &
       character(len=2*str_len_arr) :: "unit_length", "unit_time", "unit_density", &
       "unit_velocity", "unit_temperature", "unit_pressure", "unit_magneticfield", &
-      "unit_numberdensity", "unit_lambdaT", "unit_conduction", "unit_resistivity" &
+      "unit_numberdensity", "unit_lambdaT", "unit_conduction", "unit_resistivity", &
+      "mean_molecular_weight" &
     ]
     ! fill B01 array
     b01_array = B_field % B01
@@ -135,7 +136,7 @@ contains
     write(dat_fh) size(unit_names), len(unit_names(1)), unit_names
     write(dat_fh) unit_length, unit_time, unit_density, unit_velocity, &
       unit_temperature, unit_pressure, unit_magneticfield, unit_numberdensity, &
-      unit_lambdaT, unit_conduction, unit_resistivity
+      unit_lambdaT, unit_conduction, unit_resistivity, mean_molecular_weight
 
     ! Next write the data itself
     ! General data: eigenvalues, grids, equilibrium configuration

--- a/src/equilibria/smod_equil_discrete_alfven.f08
+++ b/src/equilibria/smod_equil_discrete_alfven.f08
@@ -48,7 +48,12 @@ contains
       use_fixed_tc_perp = .true.
       fixed_tc_perp_value = 0.0d0
       cgs_units = .true.
-      call set_normalisations(new_unit_density=1.5d-15, new_unit_magneticfield=50.0d0, new_unit_length=1.0d10)
+      call set_normalisations( &
+        new_unit_density=1.5d-15, &
+        new_unit_magneticfield=50.0d0, &
+        new_unit_length=1.0d10, &
+        new_mean_molecular_weight=1.0d0 & ! pure proton plasma
+      )
 
       j0 = 0.125d0
       delta = 0.2d0   ! d parameter in density prescription

--- a/src/equilibria/smod_equil_gold_hoyle.f08
+++ b/src/equilibria/smod_equil_gold_hoyle.f08
@@ -69,19 +69,22 @@ contains
       call set_normalisations( &
         new_unit_density=1.6727d-15, &
         new_unit_magneticfield=22.5d0, &
-        new_unit_length=1.0d10 &
+        new_unit_length=1.0d10, &
+        new_mean_molecular_weight=1.0d0 & ! pure proton plasma
       )
       ! hot plasma: B = 67.0 G, rho = 1.6726e-12 kg/m3, R = 1e9 m, T = 2.6e6 K
       ! call set_normalisations( &
       !   new_unit_density=1.6727d-15, &
       !   new_unit_magneticfield=67.0d0, &
-      !   new_unit_length=1.0d11 &
+      !   new_unit_length=1.0d11, &
+      !   new_mean_molecular_weight=1.0d0 & ! pure proton plasma
       ! )
       ! cold plasma: B = 10.0 G, rho = 1.6726e-12 kg/m3, R = 1e8 m, T = 5.7e4 K
       ! call set_normalisations( &
       !   new_unit_density=1.6727d-15, &
       !   new_unit_magneticfield=10.0d0, &
-      !   new_unit_length=1.0d10 &
+      !   new_unit_length=1.0d10, &
+      !   new_mean_molecular_weight=1.0d0 & ! pure proton plasma
       ! )
     end if ! LCOV_EXCL_STOP
 

--- a/src/equilibria/smod_equil_magnetothermal_instabilities.f08
+++ b/src/equilibria/smod_equil_magnetothermal_instabilities.f08
@@ -53,7 +53,8 @@ contains
       call set_normalisations( &
         new_unit_temperature=2.6d6, &
         new_unit_magneticfield=10.0d0, &
-        new_unit_length=1.00d8 &
+        new_unit_length=1.00d8, &
+        new_mean_molecular_weight=1.0d0 & ! this work assumes pure proton plasma
       )
 
       cte_T0 = 1.0d0

--- a/src/mod_version.f08
+++ b/src/mod_version.f08
@@ -14,6 +14,6 @@ module mod_version
   implicit none
 
   !> legolas version number
-  character(len=10), parameter    :: LEGOLAS_VERSION = "1.1.0"
+  character(len=10), parameter    :: LEGOLAS_VERSION = "1.1.2"
 
 end module mod_version

--- a/tests/regression_tests/test_discrete_alfven.py
+++ b/tests/regression_tests/test_discrete_alfven.py
@@ -19,6 +19,7 @@ discrete_alfven_setup = {
         "unit_density": 1.5e-15,
         "unit_magneticfield": 50.0,
         "unit_length": 1.0e10,
+        "mean_molecular_weight": 1.0,
         "logging_level": 0,
         "show_results": False,
         "write_eigenfunctions": False,

--- a/tests/regression_tests/test_gold_hoyle.py
+++ b/tests/regression_tests/test_gold_hoyle.py
@@ -25,6 +25,7 @@ gold_hoyle_setup = {
         "unit_density": 1.6727e-15,
         "unit_magneticfield": 22.5,
         "unit_length": 1.0e10,
+        "mean_molecular_weight": 1.0,
         "logging_level": 0,
         "show_results": False,
         "write_eigenfunctions": False,

--- a/tests/regression_tests/test_magnetothermal.py
+++ b/tests/regression_tests/test_magnetothermal.py
@@ -23,6 +23,7 @@ magnetothermal_setup = {
         "unit_temperature": 2.6e6,
         "unit_magneticfield": 10.0,
         "unit_length": 1.0e8,
+        "mean_molecular_weight": 1.0,
         "logging_level": 0,
         "show_results": False,
         "write_eigenfunctions": False,

--- a/tests/regression_tests/test_magnetothermal_arnoldi_si.py
+++ b/tests/regression_tests/test_magnetothermal_arnoldi_si.py
@@ -23,6 +23,7 @@ magneto_arnoldi_si_setup = {
         "unit_temperature": 2.6e6,
         "unit_magneticfield": 10.0,
         "unit_length": 1.0e8,
+        "mean_molecular_weight": 1.0,
         "logging_level": 0,
         "show_results": False,
         "write_eigenfunctions": True,

--- a/tests/unit_tests/mod_suite_utils.f90
+++ b/tests/unit_tests/mod_suite_utils.f90
@@ -104,7 +104,8 @@ contains
     call set_normalisations( &
       new_unit_temperature=1.0d6, &
       new_unit_magneticfield=5.0d0, &
-      new_unit_length=1.0d10 &
+      new_unit_length=1.0d10, &
+      new_mean_molecular_weight=1.0d0 &
     )
   end subroutine set_default_units
 

--- a/tests/unit_tests/mod_test_units.pf
+++ b/tests/unit_tests/mod_test_units.pf
@@ -63,6 +63,30 @@ contains
     @assertEqual(180747742227.85196d0, unit_conduction, tolerance=TOL)
   end subroutine test_units
 
+
+  @test
+  subroutine test_units_molecular_weight_half()
+    call set_name("setting units")
+    call set_normalisations( &
+      new_unit_temperature=1.0d6, &
+      new_unit_magneticfield=5.0d0, &
+      new_unit_length=1.0d10, &
+      new_mean_molecular_weight=0.5d0 &
+    )
+    @assertEqual(0.5d0, mean_molecular_weight, tolerance=TOL)
+    @assertEqual(5.0d0, unit_magneticfield, tolerance=TOL)
+    @assertEqual(1.0d10, unit_length, tolerance=TOL)
+    @assertEqual(1.9894367886486917d0, unit_pressure, tolerance=TOL)
+    @assertEqual(1.0d6, unit_temperature, tolerance=TOL)
+    @assertEqual(2.4101533254935998d0 / 2.0d0, unit_density * 1.0d14, tolerance=TOL)
+    @assertEqual(14409434091.049740d0 / 2.0d0, unit_numberdensity, tolerance=TOL)
+    @assertEqual(12848656.960876318d0, unit_velocity, tolerance=TOL)
+    @assertEqual(778.29146115812944d0, unit_time, tolerance=TOL)
+    @assertEqual(49.244079129142825d0, unit_lambdaT * 1.0d24, tolerance=TOL)
+    @assertEqual(49.244079129142825d0, unit_dlambdaT_dT * 1.0d30, tolerance=TOL)
+    @assertEqual(255615908426.94446d0, unit_conduction, tolerance=TOL)
+  end subroutine test_units_molecular_weight_half
+
   @test
   subroutine test_unit_resistivity()
     use mod_equilibrium, only: T_field, eta_field


### PR DESCRIPTION
This PR adds the possibility to specify a molecular weight, which is used in the unit normalisations.