### PR TITLE
Pylbo: improved subplot addition

### DIFF
--- a/post_processing/pylbo/_version.py
+++ b/post_processing/pylbo/_version.py
@@ -2,7 +2,7 @@ import matplotlib
 from packaging import version
 
 # The current pylbo version number.
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 
 class VersionHandler:

--- a/post_processing/pylbo/utilities/toolbox.py
+++ b/post_processing/pylbo/utilities/toolbox.py
@@ -3,6 +3,31 @@ import matplotlib.lines as mpl_lines
 from pylbo._version import _mpl_version
 
 
+def get_axis_geometry(ax):
+    """
+    Retrieves the geometry of a given matplotlib axis.
+
+    Parameters
+    ----------
+    ax : ~matplotlib.axes.Axes
+        The axis to retrieve the geometry from.
+
+    Returns
+    -------
+    tuple
+        The geometry of the given matplotlib axis.
+    """
+    if _mpl_version >= "3.4":
+        axis_geometry = ax.get_subplotspec().get_geometry()[0:3]
+    else:
+        # this is 1-based indexing by default, use 0-based here for consistency
+        # with subplotspec in matplotlib 3.4+
+        axis_geometry = transform_to_numpy(ax.get_geometry())
+        axis_geometry[-1] -= 1
+        axis_geometry = tuple(axis_geometry)
+    return axis_geometry
+
+
 def add_pickradius_to_item(item, pickradius):
     """
     Makes a matplotlib artist pickable and adds a pickradius.

--- a/post_processing/pylbo/visualisation/figure_manager.py
+++ b/post_processing/pylbo/visualisation/figure_manager.py
@@ -300,13 +300,13 @@ class FigureWindow:
                 f"invalid loc={loc}, expected ['top', 'right', 'bottom', 'left']"
             )
 
-        _geometry = transform_to_numpy(get_axis_geometry(self.ax))
+        _geometry = transform_to_numpy(get_axis_geometry(ax))
         subplot_index = _geometry[-1]
         gspec_outer = gridspec.GridSpec(*_geometry[0:2], figure=self.fig)
         gspec_inner = gridspec.GridSpecFromSubplotSpec(
             *subplot_geometry, subplot_spec=gspec_outer[subplot_index]
         )
-        self.ax.set_subplotspec(gspec_inner[old_new_position[0]])
+        ax.set_subplotspec(gspec_inner[old_new_position[0]])
         new_axis = self.fig.add_subplot(
             gspec_inner[old_new_position[1]], sharex=sharex, sharey=sharey
         )

--- a/post_processing/pylbo/visualisation/matrices.py
+++ b/post_processing/pylbo/visualisation/matrices.py
@@ -13,8 +13,7 @@ class MatrixFigure(FigureWindow):
         self.dataset = dataset
         self.kwargs = kwargs
 
-        self.ax.change_geometry(1, 2, 1)
-        self.ax2 = self.fig.add_subplot(122)
+        self.ax2 = self._add_subplot_axes(self.ax, loc="right")
         self.draw()
 
     def draw(self):

--- a/post_processing/pylbo/visualisation/spectra.py
+++ b/post_processing/pylbo/visualisation/spectra.py
@@ -663,10 +663,8 @@ class SpectrumComparisonPlot(SpectrumFigure):
         """Splits the original 1x2 plot into a 2x2 plot."""
         if self._axes_set:
             return
-        self.panel1.ax.change_geometry(2, 2, 1)
-        self.panel1._ef_ax = self.panel1.fig.add_subplot(2, 2, 3)
-        self.panel2.ax.change_geometry(2, 2, 2)
-        self.panel2._ef_ax = self.panel2.fig.add_subplot(2, 2, 4)
+        self.panel1._ef_ax = self.panel1._add_subplot_axes(self.panel1.ax, loc="bottom")
+        self.panel2._ef_ax = self.panel2._add_subplot_axes(self.panel2.ax, loc="bottom")
         self._axes_set = True
 
     def add_eigenfunctions(self):

--- a/post_processing/setup.py
+++ b/post_processing/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from pathlib import Path
 
 package_name = "pylbo"
-required_packages = ["numpy", "matplotlib", "f90nml", "tqdm", "psutil"]
+required_packages = ["numpy", "matplotlib", "f90nml", "tqdm", "psutil", "packaging"]
 
 version_filepath = (Path(__file__).parent / "pylbo/_version.py").resolve()
 VERSION = None

--- a/tests/pylbo_tests/test_figure_manager.py
+++ b/tests/pylbo_tests/test_figure_manager.py
@@ -1,0 +1,260 @@
+import pytest
+import matplotlib.pyplot as plt
+from pylbo.visualisation.figure_manager import FigureWindow
+from pylbo.utilities.toolbox import get_axis_geometry
+
+
+def test_create_window():
+    p = FigureWindow("test")
+    assert p.figure_id == "test-1"
+    assert get_axis_geometry(p.ax) == (1, 1, 0)
+
+
+def test_add_subplot_invalid():
+    p = FigureWindow("test")
+    with pytest.raises(ValueError):
+        p._add_subplot_axes(p.ax, loc="unknown")
+
+
+# ========== TESTS FOR RIGHT SUBPLOT ADDITION ==========
+def test_add_subplot_singleplot_right():
+    p = FigureWindow("test")
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(p.ax) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 2
+
+
+def test_add_subplot_multiple_columns_right_end():
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(ax1) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_columns_right_middle():
+    fig, (ax0, ax2) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert get_axis_geometry(ax2) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_right_top():
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert len(fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_right_middle():
+    fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(ax0) == (3, 1, 0)
+    assert get_axis_geometry(ax1) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert get_axis_geometry(ax2) == (3, 1, 2)
+    assert len(fig.get_axes()) == 4
+
+
+def test_add_subplot_matrix_right():
+    fig, axes = plt.subplots(3, 3)
+    p = FigureWindow("test", custom_figure=(fig, axes[1, 0]))
+    new_ax = p._add_subplot_axes(p.ax, loc="right")
+    assert get_axis_geometry(axes[0, 0]) == (3, 3, 0)
+    assert get_axis_geometry(axes[1, 1]) == (3, 3, 4)
+    assert get_axis_geometry(p.ax) == (1, 2, 0)
+    assert get_axis_geometry(new_ax) == (1, 2, 1)
+    assert len(fig.get_axes()) == 10
+
+
+# ========== TESTS FOR LEFT SUBPLOT ADDITION ==========
+def test_add_subplot_singleplot_left():
+    p = FigureWindow("test")
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(p.ax) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert len(p.fig.get_axes()) == 2
+
+
+def test_add_subplot_multiple_columns_left_end():
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(ax1) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_columns_left_front():
+    fig, (ax0, ax2) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(ax0) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert get_axis_geometry(ax2) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_left_top():
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(ax0) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert len(fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_left_middle():
+    fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(ax0) == (3, 1, 0)
+    assert get_axis_geometry(ax1) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert get_axis_geometry(ax2) == (3, 1, 2)
+    assert len(fig.get_axes()) == 4
+
+
+def test_add_subplot_matrix_left():
+    fig, axes = plt.subplots(3, 3)
+    p = FigureWindow("test", custom_figure=(fig, axes[0, 2]))
+    new_ax = p._add_subplot_axes(p.ax, loc="left")
+    assert get_axis_geometry(axes[0, 1]) == (3, 3, 1)
+    assert get_axis_geometry(axes[1, 2]) == (3, 3, 5)
+    assert get_axis_geometry(p.ax) == (1, 2, 1)
+    assert get_axis_geometry(new_ax) == (1, 2, 0)
+    assert len(fig.get_axes()) == 10
+
+
+# ========== TESTS FOR TOP SUBPLOT ADDITION ==========
+def test_add_subplot_singleplot_top():
+    p = FigureWindow("test")
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(p.ax) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert len(p.fig.get_axes()) == 2
+
+
+def test_add_subplot_multiple_columns_top_end():
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_columns_top_front():
+    fig, (ax0, ax2) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(ax0) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert get_axis_geometry(ax2) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_top():
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(ax0) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert len(fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_top_middle():
+    fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(ax0) == (3, 1, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert get_axis_geometry(ax2) == (3, 1, 2)
+    assert len(fig.get_axes()) == 4
+
+
+def test_add_subplot_matrix_top():
+    fig, axes = plt.subplots(3, 3)
+    p = FigureWindow("test", custom_figure=(fig, axes[1, 1]))
+    new_ax = p._add_subplot_axes(p.ax, loc="top")
+    assert get_axis_geometry(axes[0, 2]) == (3, 3, 2)
+    assert get_axis_geometry(axes[1, 2]) == (3, 3, 5)
+    assert get_axis_geometry(p.ax) == (2, 1, 1)
+    assert get_axis_geometry(new_ax) == (2, 1, 0)
+    assert len(fig.get_axes()) == 10
+
+
+# ========== TESTS FOR BOTTOM SUBPLOT ADDITION ==========
+def test_add_subplot_singleplot_bottom():
+    p = FigureWindow("test")
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(p.ax) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert len(p.fig.get_axes()) == 2
+
+
+def test_add_subplot_multiple_columns_bottom_end():
+    fig, (ax0, ax1) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(ax0) == (1, 2, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_columns_bottom_front():
+    fig, (ax0, ax2) = plt.subplots(1, 2)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(ax0) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert get_axis_geometry(ax2) == (1, 2, 1)
+    assert len(p.fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_bottom():
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax0))
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(ax0) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert get_axis_geometry(ax1) == (2, 1, 1)
+    assert len(fig.get_axes()) == 3
+
+
+def test_add_subplot_multiple_rows_bottom_middle():
+    fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
+    p = FigureWindow("test", custom_figure=(fig, ax1))
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(ax0) == (3, 1, 0)
+    assert get_axis_geometry(ax1) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert get_axis_geometry(ax2) == (3, 1, 2)
+    assert len(fig.get_axes()) == 4
+
+
+def test_add_subplot_matrix_bottom():
+    fig, axes = plt.subplots(3, 3)
+    p = FigureWindow("test", custom_figure=(fig, axes[2, 1]))
+    new_ax = p._add_subplot_axes(p.ax, loc="bottom")
+    assert get_axis_geometry(axes[0, 2]) == (3, 3, 2)
+    assert get_axis_geometry(axes[1, 2]) == (3, 3, 5)
+    assert get_axis_geometry(p.ax) == (2, 1, 0)
+    assert get_axis_geometry(new_ax) == (2, 1, 1)
+    assert len(fig.get_axes()) == 10

--- a/tests/pylbo_tests/test_toolbox.py
+++ b/tests/pylbo_tests/test_toolbox.py
@@ -1,6 +1,29 @@
 import pytest
 import numpy as np
+import matplotlib.pyplot as plt
 from pylbo.utilities import toolbox
+
+
+def test_geometry_single_figure():
+    _, ax = plt.subplots(1)
+    assert toolbox.get_axis_geometry(ax) == (1, 1, 0)
+
+
+def test_geometry_multiple_columns():
+    _, axes = plt.subplots(1, 3)
+    assert toolbox.get_axis_geometry(axes[1]) == (1, 3, 1)
+
+
+def test_geometry_multiple_rows():
+    _, axes = plt.subplots(4, 1)
+    assert toolbox.get_axis_geometry(axes[2]) == (4, 1, 2)
+
+
+def test_geometry_multiple_rows_and_columns():
+    _, axes = plt.subplots(3, 3)
+    assert toolbox.get_axis_geometry(axes[0, 1]) == (3, 3, 1)
+    assert toolbox.get_axis_geometry(axes[1, 1]) == (3, 3, 4)
+    assert toolbox.get_axis_geometry(axes[2, 0]) == (3, 3, 6)
 
 
 def test_enumerate():

--- a/tests/pylbo_tests/test_visualisations_spectra.py
+++ b/tests/pylbo_tests/test_visualisations_spectra.py
@@ -83,11 +83,11 @@ def test_spectrum_plot_save(tmpdir, ds_v112):
     assert filepath.is_file()
 
 
-def test_spectrum_plot_custom_figure_fail(ds_v112):
+def test_spectrum_plot_custom_figure_efs(ds_v112):
     fig, axes = plt.subplots(1, 2)
     p = pylbo.plot_spectrum(ds_v112, custom_figure=(fig, axes[0]))
-    with pytest.raises(ValueError):
-        p.add_eigenfunctions()
+    p.add_eigenfunctions()
+    assert len(fig.get_axes()) == 3
 
 
 def test_spectrum_plot_custom_figure(ds_v112):

--- a/tests/pylbo_tests/test_visualisations_spectra.py
+++ b/tests/pylbo_tests/test_visualisations_spectra.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import pylbo
 from pylbo.visualisation.spectra import SingleSpectrumPlot
 from pylbo.exceptions import EigenfunctionsNotPresent
+from pylbo.utilities.toolbox import get_axis_geometry
 
 
 def test_spectrum_plot_invalid_data(series_v112):
@@ -294,7 +295,8 @@ def test_comparison_plot_continua(ds_v100, ds_v112):
 def test_comparison_plot_eigenfunctions(ds_v112):
     p = pylbo.plot_spectrum_comparison(ds_v112, ds_v112)
     p.add_eigenfunctions()
-    for panel, position in zip(
-        (p.panel1.ax, p.panel2.ax, p.panel1.ef_ax, p.panel2.ef_ax), np.arange(0, 4)
-    ):
-        assert panel.get_subplotspec().get_geometry()[0:3] == (2, 2, position)
+    assert get_axis_geometry(p.panel1.ax) == (2, 1, 0)
+    assert get_axis_geometry(p.panel1.ef_ax) == (2, 1, 1)
+    assert get_axis_geometry(p.panel2.ax) == (2, 1, 0)
+    assert get_axis_geometry(p.panel2.ef_ax) == (2, 1, 1)
+    assert len(p.fig.get_axes()) == 4


### PR DESCRIPTION
## PR description
Improves the `_add_subplot_axes` method in the FigureManager to be compatible with more complex subplot layouts, also fixes the deprecationwarning for `change_geometry` from matplotlib 3.4 onwards. Closes #76.
Also fixes the "packaging" dependency issue in the `setup.py` installation file.
