### PR TITLE
Fix segmentation fault for macOS if `write_eigenfunctions = .false.`

### DIFF
--- a/src/main.f08
+++ b/src/main.f08
@@ -105,6 +105,12 @@ contains
       call log_message("allocating eigenvector arrays", level="debug")
       ! we need #rows = matrix dimension, #cols = #eigenvalues
       allocate(eigenvecs_right(matrix_gridpts, nb_evs))
+    else
+      ! @note: this is needed to prevent segfaults, since it seems that in some
+      ! cases for macOS the routine zgeev references the right eigenvectors even
+      ! if they are not requested.
+      call log_message("allocating eigenvector arrays as dummy", level="debug")
+      allocate(eigenvecs_right(2, 2))
     end if
   end subroutine initialisation
 


### PR DESCRIPTION
## PR description
This fixes a macOS-only bug where a segmentation fault is thrown when `write_eigenfunctions = .false.`. Fixed this by setting the right eigenvector array to a dummy variable so it can be referenced. Closes #82.