### PR TITLE
Introduce a dynamic state vector

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ set (sources
         dataIO/mod_exceptions.f08
         dataIO/mod_logging.f08
         mod_physical_constants.f08
+        utils/mod_get_indices.f08
         mod_units.f08
         mod_grid.f08
         mod_types.f08

--- a/src/boundaries/mod_boundary_manager.f08
+++ b/src/boundaries/mod_boundary_manager.f08
@@ -39,7 +39,7 @@ module mod_boundary_manager
 contains
 
   subroutine apply_boundary_conditions(matrixA, matrixB)
-    use mod_global_variables, only: dim_quadblock, matrix_gridpts
+    use mod_global_variables, only: dim_quadblock
 
     !> the A-matrix with boundary conditions imposed on exit
     complex(dp), intent(inout)  :: matrixA(:, :)
@@ -51,7 +51,7 @@ contains
     ! first gridpoint quadblock runs from idx 1 to l_end
     l_end = dim_quadblock
     ! last gridpoint quadblock runs from idx r_start to
-    r_start = matrix_gridpts - dim_quadblock + 1
+    r_start = size(matrixA, dim=1) - dim_quadblock + 1
 
     call set_boundary_flags()
 

--- a/src/boundaries/smod_essential_boundaries.f08
+++ b/src/boundaries/smod_essential_boundaries.f08
@@ -1,79 +1,117 @@
 submodule (mod_boundary_manager) smod_essential_boundaries
   use mod_global_variables, only: dp_LIMIT, boundary_type, geometry, coaxial
   use mod_equilibrium_params, only: k2, k3
+  use mod_check_values, only: is_zero
 
   implicit none
+
+  character(len=3), allocatable :: cubic_vars_to_zero_out(:)
 
 contains
 
   module procedure apply_essential_boundaries_left
-    complex(dp) :: diagonal_factor
-
-    diagonal_factor = get_diagonal_factor(matrix)
+    use mod_get_indices, only: get_subblock_index
 
     ! on the left side we have a zero in a quadratic basis function (number 2), which
     ! zeroes out the odd rows/columns. We explicitly handle this by introducing an
-    ! element on the diagonal for these indices as well. The odd numbered indices for
-    ! the quadratic elements correspond to rho, v2, v3, T, a1 = 1, 5, 7, 9, 11.
-    call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[1, 5, 7, 9, 11])
-    ! wall or regularity conditions: v1 and (k3 * a2 - k2 * a3) have to be zero. These are cubic
-    ! elements, so we force non-zero basis functions (odd rows & columns) to zero.
-    ! for wall we force a2 = a3 = 0 regardless of k2 and k3, for wall_weak we
-    ! only force a2 resp. a3 to zero if k3 resp. k2 is nonzero
-    if (boundary_type == 'wall') then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[3, 13, 15])
-    else if (boundary_type == 'wall_weak') then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[3])
-      if (abs(k2) > dp_LIMIT) then
-        call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[15])
-      end if
-      if (abs(k3) > dp_LIMIT) then
-        call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[13])
-      end if
+    ! element on the diagonal for these indices as well.
+    call zero_out_row_and_col( &
+      quadblock=quadblock, &
+      diagonal_factor=get_diagonal_factor(matrix), &
+      idxs=get_subblock_index( &
+        [character(len=3) :: "rho", "v2", "v3", "T", "a1"], odd=.true., edge="left" &
+      ) &
+    )
+
+    ! wall/regularity conditions: v1 has to be zero. Cubic, odd row/col to zero
+    cubic_vars_to_zero_out = ["v1"]
+    ! wall/regularity conditions: (k3 * a2 - k2 * a3) has to be zero.
+    if (boundary_type == "wall") then
+      ! for "wall" we force a2 = a3 = 0 regardless of k2 and k3
+      cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a2", "a3"]
+    else if (boundary_type == "wall_weak") then
+      ! for "wall_weak" we only force a2 resp. a3 to zero if k3 resp. k2 is nonzero
+      if (.not. is_zero(k2)) cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a3"]
+      if (.not. is_zero(k3)) cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a2"]
     end if
-    ! if T boundary conditions are needed, set even row/colum (quadratic)
+    ! apply wall/regularity conditions
+    call zero_out_row_and_col( &
+      quadblock=quadblock, &
+      diagonal_factor=get_diagonal_factor(matrix), &
+      idxs=get_subblock_index(cubic_vars_to_zero_out, odd=.true., edge="left") &
+    )
+
+    ! if T boundary conditions are needed, set even row/colum (quadratic) to zero
     if (apply_T_bounds) then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[10])
+      call zero_out_row_and_col( &
+        quadblock=quadblock, &
+        diagonal_factor=get_diagonal_factor(matrix), &
+        idxs=get_subblock_index(["T"], odd=.false., edge="left") &
+      )
     end if
     ! if no-slip boundary conditions are needed, then v2 and v3 should equal the
     ! wall's tangential velocities, here zero in the even rows/columns (both quadratic)
     if (apply_noslip_bounds_left) then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[6, 8])
+      call zero_out_row_and_col( &
+        quadblock=quadblock, &
+        diagonal_factor=get_diagonal_factor(matrix), &
+        idxs=get_subblock_index(["v2", "v3"], odd=.false., edge="left") &
+      )
     end if
+
+    if (allocated(cubic_vars_to_zero_out)) deallocate(cubic_vars_to_zero_out)
   end procedure apply_essential_boundaries_left
 
 
   module procedure apply_essential_boundaries_right
-    complex(dp) :: diagonal_factor
+    use mod_get_indices, only: get_subblock_index
 
-    diagonal_factor = get_diagonal_factor(matrix)
-
-    ! for a fixed wall v1 and (k3 * a2 - k2 * a3) should be zero, same reasoning as for left side.
-    if (boundary_type == 'wall') then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[19, 29, 31])
-    else if (boundary_type == 'wall_weak') then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[19])
-      if (abs(k2) > dp_LIMIT) then
-        call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[31])
-      end if
-      if (abs(k3) > dp_LIMIT) then
-        call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[29])
-      end if
+    ! fixed wall: v1 should be zero
+    cubic_vars_to_zero_out = ["v1"]
+    write(*, *) cubic_vars_to_zero_out
+    if (boundary_type == "wall") then
+      cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a2", "a3"]
+    else if (boundary_type == "wall_weak") then
+      ! (k3 * a2 - k2 * a3) should be zero
+      if (.not. is_zero(k2)) cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a3"]
+      if (.not. is_zero(k3)) cubic_vars_to_zero_out = [cubic_vars_to_zero_out, "a2"]
     end if
+    ! apply wall/regularity conditions
+    call zero_out_row_and_col( &
+      quadblock=quadblock, &
+      diagonal_factor=get_diagonal_factor(matrix), &
+      idxs=get_subblock_index(cubic_vars_to_zero_out, odd=.true., edge="right") &
+    )
+
     ! T condition
     if (apply_T_bounds) then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[26])
+      call zero_out_row_and_col( &
+        quadblock=quadblock, &
+        diagonal_factor=get_diagonal_factor(matrix), &
+        idxs=get_subblock_index(["T"], odd=.false., edge="right") &
+      )
     end if
     ! no-slip condition
     if (apply_noslip_bounds_right) then
-      call set_row_col_to_value(quadblock, val=diagonal_factor, idxs=[22, 24])
+      call zero_out_row_and_col( &
+        quadblock=quadblock, &
+        diagonal_factor=get_diagonal_factor(matrix), &
+        idxs=get_subblock_index(["v2", "v3"], odd=.false., edge="right") &
+      )
     end if
+
+    if (allocated(cubic_vars_to_zero_out)) deallocate(cubic_vars_to_zero_out)
   end procedure apply_essential_boundaries_right
 
 
-  subroutine set_row_col_to_value(quadblock, val, idxs)
-    complex(dp), intent(inout) :: quadblock(:, :)
-    complex(dp), intent(in) :: val
+  !> Zeroes out the row and column corresponding to the given indices.
+  !! Afterwards `diagonal_factor` is introduced in that row/column on the main diagonal.
+  subroutine zero_out_row_and_col(quadblock, diagonal_factor, idxs)
+    !> quadblock at the left or right edge, modified on exit
+    complex(dp), intent(inout)  :: quadblock(:, :)
+    !> value to introduce on the main diagonal
+    complex(dp), intent(in) :: diagonal_factor
+    !> indices of the row and column to zero out
     integer, intent(in) :: idxs(:)
     integer :: i, j
 
@@ -81,9 +119,9 @@ contains
       j = idxs(i)
       quadblock(j, :) = (0.0d0, 0.0d0)
       quadblock(:, j) = (0.0d0, 0.0d0)
-      quadblock(j, j) = val
+      quadblock(j, j) = diagonal_factor
     end do
-  end subroutine set_row_col_to_value
+  end subroutine zero_out_row_and_col
 
 
   function get_diagonal_factor(matrix) result(diagonal_factor)

--- a/src/dataIO/mod_exceptions.f08
+++ b/src/dataIO/mod_exceptions.f08
@@ -74,10 +74,10 @@ contains
 
     !> message to print to the console when exception is raised
     character(len=*), intent(in) :: msg
-    character(len=str_len) :: msg_painted
+    character(len=3*str_len) :: msg_painted
 
     call paint_string(" ERROR   | " // msg, "red", msg_painted)
-    write(*, *) msg_painted
+    write(*, *) trim(msg_painted)
     error stop
   end subroutine on_exception_raised
   ! LCOV_EXCL_STOP

--- a/src/dataIO/mod_logging.f08
+++ b/src/dataIO/mod_logging.f08
@@ -184,7 +184,7 @@ contains
     call log_message("grid end           : " // str(x_end))
     call log_message("gridpoints (base)  : " // str(gridpts))
     call log_message("gridpoints (Gauss) : " // str(gauss_gridpts))
-    call log_message("gridpoints (matrix): " // str(matrix_gridpts))
+    call log_message("gridpoints (matrix): " // str(dim_matrix))
 
     call log_message("          << Equilibrium settings >>")
     call log_message("equilibrium    : " // trim(adjustl(equilibrium_type)))

--- a/src/dataIO/mod_logging.f08
+++ b/src/dataIO/mod_logging.f08
@@ -28,6 +28,7 @@ module mod_logging
     module procedure int_tostr
     module procedure float_tostr
     module procedure complex_tostr
+    module procedure character_arr_tostr
   end interface str
 
   !> logical used to (locally) force a prefix override
@@ -339,6 +340,22 @@ contains
     write(char_log2, '(SP,' // format // ',"i")') aimag(value)
     result_str = trim(adjustl(char_log)) // trim(adjustl(char_log2))
   end function complex_tostr
+
+
+  !> Converts an array of characters to a string.
+  function character_arr_tostr(array) result(result_str)
+    !> the array to convert
+    character(len=*), intent(in)  :: array(:)
+    !> returned result, trimmed
+    character(:), allocatable :: result_str
+    integer :: i
+
+    result_str = "["
+    do i = 1, size(array)
+      result_str = result_str // trim(array(i)) // ", "
+    end do
+    result_str = result_str(:len(result_str) - 2) // "]"
+  end function character_arr_tostr
 
 
   ! LCOV_EXCL_START <not used during testing>

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -162,7 +162,7 @@ contains
     ! Eigenfunction data [optional]
     if (write_eigenfunctions) then
       call log_message("writing eigenfunctions...", level="info")
-      write(dat_fh) size(ef_names), ef_names
+      write(dat_fh) size(state_vector), state_vector
       write(dat_fh) ef_grid
       write(dat_fh) size(ef_written_flags), ef_written_flags
       write(dat_fh) size(ef_written_idxs), ef_written_idxs

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -126,7 +126,7 @@ contains
     ! First we write all header information
     write(dat_fh) "legolas_version", LEGOLAS_VERSION
     write(dat_fh) str_len, str_len_arr, geometry, x_start, x_end, gridpts, &
-      gauss_gridpts, matrix_gridpts, ef_gridpts, gamma, equilibrium_type, &
+      gauss_gridpts, dim_matrix, ef_gridpts, gamma, equilibrium_type, &
       write_eigenfunctions, write_derived_eigenfunctions, write_matrices, &
       write_eigenfunction_subset, eigenfunction_subset_center, &
       eigenfunction_subset_radius
@@ -188,8 +188,8 @@ contains
       ! to correctly read in the values later on (we have to know how many there are).
       nonzero_B_values = 0
       nonzero_A_values = 0
-      do j = 1, matrix_gridpts
-        do i = 1, matrix_gridpts
+      do j = 1, size(matrix_A, dim=2)
+        do i = 1, size(matrix_A, dim=1)
           if (.not. is_equal(matrix_B(i, j), 0.0d0)) then
             nonzero_B_values = nonzero_B_values + 1
           end if
@@ -200,8 +200,8 @@ contains
       end do
       ! write these numbers to the file
       write(dat_fh) nonzero_B_values, nonzero_A_values
-      do j = 1, matrix_gridpts
-        do i = 1, matrix_gridpts
+      do j = 1, size(matrix_B, dim=2)
+        do i = 1, size(matrix_B, dim=1)
           if (.not. is_equal(matrix_B(i, j), 0.0d0)) then
             write(dat_fh) i, j
             write(dat_fh) matrix_B(i, j)
@@ -209,8 +209,8 @@ contains
         end do
       end do
       ! Write non-zero A matrix indices and values
-      do j = 1, matrix_gridpts
-        do i = 1, matrix_gridpts
+      do j = 1, size(matrix_A, dim=2)
+        do i = 1, size(matrix_A, dim=1)
           if (.not. is_equal(matrix_A(i, j), (0.0d0, 0.0d0))) then
             write(dat_fh) i, j
             write(dat_fh) matrix_A(i, j)

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -82,7 +82,6 @@ module mod_eigenfunctions
   public :: derived_eigenfunctions
   public :: initialise_eigenfunctions
   public :: calculate_eigenfunctions
-  public :: find_name_loc_in_array
   public :: retrieve_eigenfunctions
   public :: retrieve_eigenfunction_from_index
   public :: eigenfunctions_clean
@@ -120,32 +119,11 @@ contains
   end subroutine calculate_eigenfunctions
 
 
-  !> Function to locate the index of a given name in a character array.
-  !! Iterates over the elements and returns on the first hit, if no match
-  !! was found zero is returned.
-  function find_name_loc_in_array(name, array) result(match_idx)
-    !> the name to search for
-    character(len=*), intent(in)  :: name
-    !> array with the names to search in
-    character(len=*), intent(in)  :: array(:)
-    !> index of first match
-    integer :: match_idx
-    integer :: i
-
-    match_idx = 0
-    do i = 1, size(array)
-      if (array(i) == name) then
-        match_idx = i
-        exit
-      end if
-    end do
-  end function find_name_loc_in_array
-
-
   !> Returns the full set of eigenfunctions corresponding to the given eigenfunction
   !! name.
   function retrieve_eigenfunctions(name) result(eigenfunctions)
     use mod_logging, only: log_message
+    use mod_check_values, only: get_index
 
     !> name of the eigenfunction to retrieve
     character(len=*), intent(in)  :: name
@@ -154,7 +132,7 @@ contains
     integer :: name_idx
 
     ! check if we want a regular eigenfunction
-    name_idx = find_name_loc_in_array(name, state_vector)
+    name_idx = get_index(name, state_vector)
     if (name_idx > 0) then
       ! found, retrieve and return
       eigenfunctions = base_eigenfunctions(name_idx)
@@ -162,7 +140,7 @@ contains
     end if
     ! not found (= 0), try a derived quantity
     if (derived_efs_initialised) then
-      name_idx = find_name_loc_in_array(name, derived_ef_names)
+      name_idx = get_index(name, derived_ef_names)
       if (name_idx > 0) then
         eigenfunctions = derived_eigenfunctions(name_idx)
         return

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -3,7 +3,7 @@
 !! and interfaces to initialise and calculate the eigenfunctions and
 !! derived quantities.
 module mod_eigenfunctions
-  use mod_global_variables, only: dp, str_len_arr, ef_gridpts
+  use mod_global_variables, only: dp, str_len_arr, ef_gridpts, state_vector
   use mod_types, only: ef_type
   implicit none
 
@@ -19,8 +19,6 @@ module mod_eigenfunctions
   real(dp), protected, allocatable :: ef_eps(:)
   !> derivative of scale factor
   real(dp), protected :: ef_deps
-  !> array with the names of the basis eigenfunctions
-  character(str_len_arr), protected, allocatable :: ef_names(:)
   !> array with the names of the derived eigenfunctions
   character(str_len_arr), protected, allocatable :: derived_ef_names(:)
   !> logical array containing flags for written eigenfunctions
@@ -78,7 +76,7 @@ module mod_eigenfunctions
   end interface
 
   public :: ef_grid
-  public :: ef_names, derived_ef_names
+  public :: derived_ef_names
   public :: ef_written_flags, ef_written_idxs
   public :: base_eigenfunctions
   public :: derived_eigenfunctions
@@ -156,7 +154,7 @@ contains
     integer :: name_idx
 
     ! check if we want a regular eigenfunction
-    name_idx = find_name_loc_in_array(name, ef_names)
+    name_idx = find_name_loc_in_array(name, state_vector)
     if (name_idx > 0) then
       ! found, retrieve and return
       eigenfunctions = base_eigenfunctions(name_idx)
@@ -279,7 +277,6 @@ contains
       deallocate(ef_eps)
       deallocate(ef_written_flags)
       deallocate(ef_written_idxs)
-      deallocate(ef_names)
       if (derived_efs_initialised) then
         call clean_derived_eigenfunctions()
         deallocate(derived_eigenfunctions)

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -123,7 +123,7 @@ contains
   !! name.
   function retrieve_eigenfunctions(name) result(eigenfunctions)
     use mod_logging, only: log_message
-    use mod_check_values, only: get_index
+    use mod_get_indices, only: get_index
 
     !> name of the eigenfunction to retrieve
     character(len=*), intent(in)  :: name

--- a/src/eigenfunctions/smod_base_efs.f08
+++ b/src/eigenfunctions/smod_base_efs.f08
@@ -11,14 +11,10 @@ contains
   module procedure initialise_base_eigenfunctions
     integer :: i
 
-    ef_names = [ &
-      character(len=str_len_arr) :: "rho", "v1", "v2", "v3", "T", "a1", "a2", "a3" &
-    ]
-    allocate(base_eigenfunctions(size(ef_names)))
-
+    allocate(base_eigenfunctions(size(state_vector)))
     do i = 1, size(base_eigenfunctions)
       base_eigenfunctions(i) % state_vector_index = i
-      base_eigenfunctions(i) % name = ef_names(i)
+      base_eigenfunctions(i) % name = state_vector(i)
       allocate(base_eigenfunctions(i) % quantities(size(ef_grid), nb_eigenfuncs))
     end do
     efs_initialised = .true.

--- a/src/main.f08
+++ b/src/main.f08
@@ -58,7 +58,8 @@ contains
   !! and eigenfunctions are initialised and the equilibrium is set.
   subroutine initialisation()
     use mod_global_variables, only: initialise_globals, dim_matrix, &
-      solver, number_of_eigenvalues, write_eigenfunctions, gamma, set_gamma, NaN
+      solver, number_of_eigenvalues, write_eigenfunctions, gamma, set_gamma, NaN, &
+      state_vector
     use mod_input, only: read_parfile, get_parfile
     use mod_equilibrium, only: initialise_equilibrium, set_equilibrium, hall_field
     use mod_logging, only: print_logo
@@ -76,9 +77,7 @@ contains
     call set_gamma(gamma)
 
     call print_logo()
-
-    allocate(matrix_A(dim_matrix, dim_matrix))
-    allocate(matrix_B(dim_matrix, dim_matrix))
+    call log_message("the state vector is set to " // str(state_vector), level="info")
 
     if (solver == "arnoldi") then
       nb_evs = number_of_eigenvalues
@@ -87,6 +86,8 @@ contains
     end if
     call log_message("setting #eigenvalues to " // str(nb_evs), level="debug")
     allocate(omega(nb_evs))
+    allocate(matrix_A(dim_matrix, dim_matrix))
+    allocate(matrix_B(dim_matrix, dim_matrix))
 
     call initialise_equilibrium()
     call set_equilibrium()

--- a/src/main.f08
+++ b/src/main.f08
@@ -57,7 +57,7 @@ contains
   !! Allocates and initialises main and global variables, then the equilibrium state
   !! and eigenfunctions are initialised and the equilibrium is set.
   subroutine initialisation()
-    use mod_global_variables, only: initialise_globals, matrix_gridpts, &
+    use mod_global_variables, only: initialise_globals, dim_matrix, &
       solver, number_of_eigenvalues, write_eigenfunctions, gamma, set_gamma, NaN
     use mod_input, only: read_parfile, get_parfile
     use mod_equilibrium, only: initialise_equilibrium, set_equilibrium, hall_field
@@ -77,13 +77,13 @@ contains
 
     call print_logo()
 
-    allocate(matrix_A(matrix_gridpts, matrix_gridpts))
-    allocate(matrix_B(matrix_gridpts, matrix_gridpts))
+    allocate(matrix_A(dim_matrix, dim_matrix))
+    allocate(matrix_B(dim_matrix, dim_matrix))
 
     if (solver == "arnoldi") then
       nb_evs = number_of_eigenvalues
     else
-      nb_evs = matrix_gridpts
+      nb_evs = dim_matrix
     end if
     call log_message("setting #eigenvalues to " // str(nb_evs), level="debug")
     allocate(omega(nb_evs))
@@ -117,7 +117,7 @@ contains
     if (write_eigenfunctions .or. solver == "arnoldi") then
       call log_message("allocating eigenvector arrays", level="debug")
       ! we need #rows = matrix dimension, #cols = #eigenvalues
-      allocate(eigenvecs_right(matrix_gridpts, nb_evs))
+      allocate(eigenvecs_right(dim_matrix, nb_evs))
     else
       ! @note: this is needed to prevent segfaults, since it seems that in some
       ! cases for macOS the routine zgeev references the right eigenvectors even

--- a/src/mod_check_values.f08
+++ b/src/mod_check_values.f08
@@ -44,20 +44,12 @@ module mod_check_values
     module procedure real_array_is_constant
   end interface is_constant
 
-  !> interface to retrieve the index of an element in an array.
-   !! @note: replace get_index by `findloc` once we drop support for gfortran<9 @endnote
-  interface get_index
-    module procedure find_index_in_character_array
-    module procedure find_indices_in_character_array
-  end interface get_index
-
   public :: set_small_values_to_zero
   public :: is_NaN
   public :: is_equal
   public :: is_zero
   public :: is_negative
   public :: is_constant
-  public :: get_index
 
 contains
 
@@ -225,42 +217,5 @@ contains
 
     real_array_is_constant = all(abs(array - array(1)) <= tolerance)
   end function real_array_is_constant
-
-
-   !> Function to locate the index of a given name in a character array.
-   !! Iterates over the elements and returns on the first hit, if no match
-   !! was found zero is returned.
-  function find_index_in_character_array(name, array) result(match_idx)
-    !> the name to search for
-    character(len=*), intent(in)  :: name
-    !> array with the names to search in
-    character(len=*), intent(in)  :: array(:)
-    !> index of first match
-    integer :: match_idx
-    integer :: i
-
-    match_idx = 0
-    do i = 1, size(array)
-      if (array(i) == name) then
-        match_idx = i
-        exit
-      end if
-    end do
-  end function find_index_in_character_array
-
-
-  function find_indices_in_character_array(names, array) result(match_idxs)
-    !> the names to search for
-    character(len=*), intent(in)  :: names(:)
-    !> array in which to sarch in
-    character(len=*), intent(in)  :: array(:)
-    !> index of first matches
-    integer :: match_idxs(size(names))
-    integer :: i
-
-    do i = 1, size(names)
-      match_idxs(i) = find_index_in_character_array(names(i), array)
-    end do
-  end function find_indices_in_character_array
 
 end module mod_check_values

--- a/src/mod_check_values.f08
+++ b/src/mod_check_values.f08
@@ -44,12 +44,20 @@ module mod_check_values
     module procedure real_array_is_constant
   end interface is_constant
 
+  !> interface to retrieve the index of an element in an array.
+   !! @note: replace get_index by `findloc` once we drop support for gfortran<9 @endnote
+  interface get_index
+    module procedure find_index_in_character_array
+    module procedure find_indices_in_character_array
+  end interface get_index
+
   public :: set_small_values_to_zero
   public :: is_NaN
   public :: is_equal
   public :: is_zero
   public :: is_negative
   public :: is_constant
+  public :: get_index
 
 contains
 
@@ -217,5 +225,42 @@ contains
 
     real_array_is_constant = all(abs(array - array(1)) <= tolerance)
   end function real_array_is_constant
+
+
+   !> Function to locate the index of a given name in a character array.
+   !! Iterates over the elements and returns on the first hit, if no match
+   !! was found zero is returned.
+  function find_index_in_character_array(name, array) result(match_idx)
+    !> the name to search for
+    character(len=*), intent(in)  :: name
+    !> array with the names to search in
+    character(len=*), intent(in)  :: array(:)
+    !> index of first match
+    integer :: match_idx
+    integer :: i
+
+    match_idx = 0
+    do i = 1, size(array)
+      if (array(i) == name) then
+        match_idx = i
+        exit
+      end if
+    end do
+  end function find_index_in_character_array
+
+
+  function find_indices_in_character_array(names, array) result(match_idxs)
+    !> the names to search for
+    character(len=*), intent(in)  :: names(:)
+    !> array in which to sarch in
+    character(len=*), intent(in)  :: array(:)
+    !> index of first matches
+    integer :: match_idxs(size(names))
+    integer :: i
+
+    do i = 1, size(names)
+      match_idxs(i) = find_index_in_character_array(names(i), array)
+    end do
+  end function find_indices_in_character_array
 
 end module mod_check_values

--- a/src/mod_global_variables.f08
+++ b/src/mod_global_variables.f08
@@ -105,6 +105,9 @@ module mod_global_variables
   !> size of a single eigenfunction array, automatically set by \p gridpts
   integer, protected        :: ef_gridpts
 
+  !> array containing the current state vector
+  character(len=str_len_arr), protected, allocatable :: state_vector(:)
+
   !> number of Gaussian nodes
   integer, parameter           :: n_gauss = 4
   !> values for the Gaussian nodes in [-1, 1]
@@ -132,13 +135,13 @@ module mod_global_variables
   integer                      :: nb_spurious_eigenvalues
 
   !> total number of equations
-  integer, parameter        :: nb_eqs = 8
+  integer, protected  :: nb_eqs
   !> dimension of one finite element integral block, e.g. A(1, 2)
-  integer, parameter        :: dim_integralblock = 2
+  integer, protected  :: dim_integralblock
   !> dimension of one subblock, 4 of these define a quadblock
-  integer, parameter        :: dim_subblock = nb_eqs * dim_integralblock
+  integer, protected  :: dim_subblock
   !> dimension of one quadblock, this is the block shifted along the main diagonal
-  integer, parameter        :: dim_quadblock = 2*dim_subblock
+  integer, protected  :: dim_quadblock
   !> size of the A and B matrices
   integer, protected  :: dim_matrix
 
@@ -285,14 +288,30 @@ contains
   !> Sets all gridpoint-related variables: sets the base number of gridpoints,
   !! the gridpoints of the Gaussian grid, matrix sizes and size of the
   !! eigenfunction arrays.
-  subroutine set_gridpts(gridpts_in)
+  subroutine set_gridpts(points)
     !> amount of gridpoints for the base grid
-    integer, intent(in) :: gridpts_in
+    integer, intent(in) :: points
 
-    gridpts = gridpts_in
+    gridpts = points
     gauss_gridpts = n_gauss * (gridpts - 1)
     ef_gridpts  = 2 * gridpts - 1
-    dim_matrix = dim_subblock * gridpts
+    call set_matrix_properties(points)
   end subroutine set_gridpts
+
+
+  !> Sets dimensions for matrix A and B, subblock sizes and state vector
+  subroutine set_matrix_properties(points)
+    !> gridpoints for the base grid
+    integer, intent(in) :: points
+
+    state_vector = [ &
+      character(len=str_len_arr) :: "rho", "v1", "v2", "v3", "T", "a1", "a2", "a3" &
+    ]
+    nb_eqs = size(state_vector)
+    dim_integralblock = 2
+    dim_subblock = nb_eqs * dim_integralblock
+    dim_quadblock = dim_integralblock * dim_subblock
+    dim_matrix = dim_subblock * points
+  end subroutine set_matrix_properties
 
 end module mod_global_variables

--- a/src/mod_global_variables.f08
+++ b/src/mod_global_variables.f08
@@ -102,8 +102,6 @@ module mod_global_variables
   logical, save             :: force_r0
   !> number of gridpoints in the gaussian grid, automatically set by \p gridpts
   integer, protected        :: gauss_gridpts
-  !> size of the A and B matrices, automatically set by \p gridpts
-  integer, protected        :: matrix_gridpts
   !> size of a single eigenfunction array, automatically set by \p gridpts
   integer, protected        :: ef_gridpts
 
@@ -141,6 +139,8 @@ module mod_global_variables
   integer, parameter        :: dim_subblock = nb_eqs * dim_integralblock
   !> dimension of one quadblock, this is the block shifted along the main diagonal
   integer, parameter        :: dim_quadblock = 2*dim_subblock
+  !> size of the A and B matrices
+  integer, protected  :: dim_matrix
 
   !> boolean to write both matrices to the datfile, defaults to <tt>False</tt>
   logical, save             :: write_matrices
@@ -289,10 +289,10 @@ contains
     !> amount of gridpoints for the base grid
     integer, intent(in) :: gridpts_in
 
-    gridpts        = gridpts_in
-    gauss_gridpts  = 4*(gridpts - 1)
-    matrix_gridpts = 16 * gridpts
-    ef_gridpts     = 2*gridpts - 1
+    gridpts = gridpts_in
+    gauss_gridpts = n_gauss * (gridpts - 1)
+    ef_gridpts  = 2 * gridpts - 1
+    dim_matrix = dim_subblock * gridpts
   end subroutine set_gridpts
 
 end module mod_global_variables

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -123,10 +123,10 @@ contains
   !!          on-axis treatment (e.g. <tt>r = 0.025</tt> instead of <tt>r = 0</tt>)
   !!          usually does a better job. A warning will be thrown if eigenvalues are removed.
   subroutine handle_spurious_eigenvalues(eigenvalues)
-    use mod_global_variables, only: matrix_gridpts, remove_spurious_eigenvalues, nb_spurious_eigenvalues
+    use mod_global_variables, only: remove_spurious_eigenvalues, nb_spurious_eigenvalues
 
     !> the eigenvalues with spurious modes replaced on exit
-    complex(dp), intent(inout)  :: eigenvalues(matrix_gridpts)
+    complex(dp), intent(inout)  :: eigenvalues(:)
     integer                     :: i, idx
     complex(dp)                 :: replacement
 

--- a/src/solvers/mod_solvers.f08
+++ b/src/solvers/mod_solvers.f08
@@ -3,7 +3,7 @@
 !! submodules are defined here, and the <tt>solve_evp</tt> routine calls the
 !! correct solver based on parfile settings.
 module mod_solvers
-  use mod_global_variables, only: dp, matrix_gridpts, write_eigenfunctions
+  use mod_global_variables, only: dp, write_eigenfunctions
   use mod_logging, only: log_message, str
   use mod_check_values, only: set_small_values_to_zero
   implicit none

--- a/src/utils/mod_get_indices.f08
+++ b/src/utils/mod_get_indices.f08
@@ -1,0 +1,97 @@
+!=================================================================
+!> Module defining convenient index retrieval functions on various arrays.
+module mod_get_indices
+  implicit none
+
+  private
+
+  !> interface to retrieve the index of an element in an array.
+   !! @note: replace get_index by `findloc` once we drop support for gfortran<9 @endnote
+  interface get_index
+    module procedure find_index_in_character_array
+    module procedure find_indices_in_character_array
+  end interface get_index
+
+
+  interface get_subblock_index
+    module procedure transform_state_variable_to_subblock_index
+  end interface
+
+  public :: get_index
+  public :: get_subblock_index
+
+contains
+
+  !> Function to locate the index of a given character in a character array.
+  !! Iterates over the elements and returns on the first hit, if no match
+  !! was found zero is returned.
+  function find_index_in_character_array(name, array) result(match_idx)
+    !> the name to search for
+    character(len=*), intent(in)  :: name
+    !> array with the names to search in
+    character(len=*), intent(in)  :: array(:)
+    !> index of first match
+    integer :: match_idx
+    integer :: i
+
+    match_idx = 0
+    do i = 1, size(array)
+      if (array(i) == name) then
+        match_idx = i
+        exit
+      end if
+    end do
+  end function find_index_in_character_array
+
+
+  !> Function to locate the indices of an array of characters in another
+  !! character array. Returns the indices of the first hit, it no match was
+  !! found zero is returned.
+  function find_indices_in_character_array(names, array) result(match_idxs)
+    !> the names to search for
+    character(len=*), intent(in)  :: names(:)
+    !> array in which to sarch in
+    character(len=*), intent(in)  :: array(:)
+    !> index of first matches
+    integer :: match_idxs(size(names))
+    integer :: i
+
+    do i = 1, size(names)
+      match_idxs(i) = find_index_in_character_array(names(i), array)
+    end do
+  end function find_indices_in_character_array
+
+
+  !> Transforms a given array of state variables to subblock indices.
+  !! If `odd` is `.true.` returns the odd indices, otherwise the even indices.
+  !! If `edge` equals `"left"`, returns the indices corresponding to the left boundary
+  !! block, if `edge` equals `"right"` returns indices for the right boundary block.
+  function transform_state_variable_to_subblock_index(variables, odd, edge) result(idxs)
+    use mod_global_variables, only: state_vector, dim_subblock
+    use mod_logging, only: log_message, str
+
+    !> array of state vector variable names
+    character(len=*), intent(in)  :: variables(:)
+    !> uses odd indices if .true. and even if .false.
+    logical, intent(in) :: odd
+    !> which edge to consider, `"left"` for left boundary and `"right"` for right one
+    character(len=*), intent(in)  :: edge
+    !> integer array containing the corresponding subblock indices
+    integer, allocatable :: idxs(:)
+
+    idxs = get_index(variables, state_vector)
+    idxs = 2 * pack(idxs, idxs > 0)
+
+    if (odd) idxs = idxs - 1
+    if (edge == "right") idxs = idxs + dim_subblock
+    if (size(idxs) == 0) then
+      call log_message( &
+        "could not retrieve subblock indices for any variable in " // str(variables) &
+        // " for state vector " // str(state_vector), &
+        level="error" &
+      )
+      return
+    end if
+  end function transform_state_variable_to_subblock_index
+
+end module mod_get_indices

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(suite ${LEGOLASLIB} ${LIBSTOLINK})
 set( test_sources
         mod_test_variables.pf
         mod_test_logging.pf
+        mod_test_indices.pf
         mod_test_grid.pf
         mod_test_input.pf
         mod_test_valuechecks.pf

--- a/tests/unit_tests/mod_test_boundaries.pf
+++ b/tests/unit_tests/mod_test_boundaries.pf
@@ -2,7 +2,7 @@ module mod_test_boundaries
   use mod_suite_utils
   use funit
   use mod_boundary_manager, only: apply_boundary_conditions
-  use mod_global_variables, only: matrix_gridpts, thermal_conduction, viscosity
+  use mod_global_variables, only: dim_matrix, thermal_conduction, viscosity
   implicit none
 
   complex(dp), allocatable :: amat(:, :), amat_expected(:, :)
@@ -51,10 +51,10 @@ contains
     if (allocated(bmat_expected)) then
       deallocate(bmat_expected)
     end if
-    allocate(amat(matrix_gridpts, matrix_gridpts))
-    allocate(amat_expected(matrix_gridpts, matrix_gridpts))
-    allocate(bmat(matrix_gridpts, matrix_gridpts))
-    allocate(bmat_expected(matrix_gridpts, matrix_gridpts))
+    allocate(amat(dim_matrix, dim_matrix))
+    allocate(amat_expected(dim_matrix, dim_matrix))
+    allocate(bmat(dim_matrix, dim_matrix))
+    allocate(bmat_expected(dim_matrix, dim_matrix))
     amat = avalue
     amat_expected = avalue
     bmat = bvalue

--- a/tests/unit_tests/mod_test_eigenfunctions.pf
+++ b/tests/unit_tests/mod_test_eigenfunctions.pf
@@ -203,7 +203,7 @@ contains
     complex(dp) :: eigenfunc(ef_gridpts)
 
     call set_name("eigenfunctions - get from index")
-    call create_eigenvectors(matrix_gridpts)
+    call create_eigenvectors(dim_matrix)
     call calculate_eigenfunctions(right_eigenvectors=eigenvectors)
     eigenfunc = retrieve_eigenfunction_from_index(name="rho", ef_index=5)
   end subroutine test_ef_retrieval_index
@@ -215,7 +215,7 @@ contains
 
     call set_name("eigenfunctions - get from index (invalid name)")
     call enable_derived_efs()
-    call create_eigenvectors(matrix_gridpts)
+    call create_eigenvectors(dim_matrix)
     call calculate_eigenfunctions(right_eigenvectors=eigenvectors)
     eigenfunc = retrieve_eigenfunction_from_index(name="S", ef_index=5)
   end subroutine test_ef_retrieval_index_derived_ef
@@ -251,7 +251,7 @@ contains
     call set_name("eigenfunctions - pp sizes with bfield")
     call enable_derived_efs()
     call use_bfield(use_b01=.false.)
-    call create_eigenvectors(matrix_gridpts)
+    call create_eigenvectors(dim_matrix)
     call calculate_eigenfunctions(right_eigenvectors=eigenvectors)
     @assertEqual(size(derived_ef_names), size(derived_eigenfunctions))
     @assertTrue((any(derived_ef_names == "B_para")))

--- a/tests/unit_tests/mod_test_eigenfunctions.pf
+++ b/tests/unit_tests/mod_test_eigenfunctions.pf
@@ -9,7 +9,6 @@ module mod_test_eigenfunctions
   complex(dp) :: eigenvals(25)
   complex(dp), allocatable :: eigenvectors(:, :)
   type(ef_type) :: ef_test
-  character(len=10) :: test_names(5) = ["name1", "name2", "name3", "name4", "name5"]
 
 contains
 
@@ -116,20 +115,6 @@ contains
     @assertEqual(4, size(ef_written_idxs))
     @assertEqual([5, 9, 10, 15], ef_written_idxs)
   end subroutine test_eigenfunction_subset_idxs
-
-
-  @test
-  subroutine test_find_name_loc()
-    call set_name("eigenfunctions - retrieving name")
-    @assertEqual(2, find_name_loc_in_array("name2", test_names))
-  end subroutine test_find_name_loc
-
-
-  @test
-  subroutine test_find_name_loc_fail()
-    call set_name("eigenfunctions - retrieving name (fail)")
-    @assertEqual(0, find_name_loc_in_array("unknown", test_names))
-  end subroutine test_find_name_loc_fail
 
 
   @test

--- a/tests/unit_tests/mod_test_eigenfunctions.pf
+++ b/tests/unit_tests/mod_test_eigenfunctions.pf
@@ -133,13 +133,6 @@ contains
 
 
   @test
-  subroutine test_ef_names()
-    call set_name("eigenfunctions - names")
-    @assertEqual(8, size(ef_names))
-  end subroutine test_ef_names
-
-
-  @test
   subroutine test_ef_names_derived_no_bfield()
     call set_name("eigenfunctions - derived names (hydro)")
     call enable_derived_efs()

--- a/tests/unit_tests/mod_test_indices.pf
+++ b/tests/unit_tests/mod_test_indices.pf
@@ -1,0 +1,145 @@
+module mod_test_indices
+  use mod_suite_utils
+  use funit
+  use mod_get_indices
+  implicit none
+
+  integer, allocatable :: idxs(:)
+
+  character(len=10) :: test_names(5) = ["name1", "name2", "name3", "name4", "name5"]
+
+contains
+
+  @before
+  subroutine init_test()
+    call reset_globals()
+  end subroutine init_test
+
+
+  @after
+  subroutine tear_down()
+    if (allocated(idxs)) deallocate(idxs)
+  end subroutine tear_down
+
+
+  @test
+  subroutine test_find_name_index()
+    call set_name("get name index from array")
+    @assertEqual(2, get_index("name2", test_names))
+  end subroutine test_find_name_index
+
+
+  @test
+  subroutine test_find_name_index_fail()
+    call set_name("get name index from array (fail)")
+    @assertEqual(0, get_index("unknown", test_names))
+  end subroutine test_find_name_index_fail
+
+
+  @test
+  subroutine test_find_name_indices()
+    call set_name("get name indices from array")
+    @assertEqual([3, 4], get_index(["name3", "name4"], test_names))
+  end subroutine test_find_name_indices
+
+
+  @test
+  subroutine test_find_name_indices_partial()
+    call set_name("get name indices from array (partial)")
+    @assertEqual([5, 0, 2], get_index(["name5", "test1", "name2"], test_names))
+  end subroutine test_find_name_indices_partial
+
+
+  @test
+  subroutine test_find_name_indices_fail()
+    call set_name("get name indices from array (fail)")
+    @assertEqual([0, 0, 0], get_index(["test1", "test2", "test3"], test_names))
+  end subroutine test_find_name_indices_fail
+
+
+  @test
+  subroutine test_subblock_indices_fail()
+    character(len=1024), allocatable :: error_msg
+
+    call set_name("get subblock indices (fail)")
+    error_msg = ( &
+      "could not retrieve subblock indices for any variable in [test1, test2] " &
+      // "for state vector [rho, v1, v2, v3, T, a1, a2, a3]" &
+    )
+    idxs = get_subblock_index(variables=["test1", "test2"], odd=.true., edge="left")
+    @assertExceptionRaised(trim(error_msg))
+  end subroutine test_subblock_indices_fail
+
+
+  @test
+  subroutine test_subblock_indices_odd_left_mhd()
+    call set_name("get subblock indices (odd, left, MHD)")
+    idxs = get_subblock_index(variables=["v1", "v2", "a1"], odd=.true., edge="left")
+    @assertEqual([3, 5, 11], idxs)
+  end subroutine test_subblock_indices_odd_left_mhd
+
+
+  @test
+  subroutine test_subblock_indices_even_left_mhd()
+    call set_name("get subblock indices (even, left, MHD)")
+    idxs = get_subblock_index(variables=["v1", "v2", "a1"], odd=.false., edge="left")
+    @assertEqual([4, 6, 12], idxs)
+  end subroutine test_subblock_indices_even_left_mhd
+
+
+  @test
+  subroutine test_subblock_indices_odd_right_mhd()
+    call set_name("get subblock indices (odd, right, MHD)")
+    idxs = get_subblock_index(variables=["v1", "v2", "a1"], odd=.true., edge="right")
+    @assertEqual([19, 21, 27], idxs)
+  end subroutine test_subblock_indices_odd_right_mhd
+
+
+  @test
+  subroutine test_subblock_indices_even_right_mhd()
+    call set_name("get subblock indices (even, right, MHD)")
+    idxs = get_subblock_index(variables=["v1", "v2", "a1"], odd=.false., edge="right")
+    @assertEqual([20, 22, 28], idxs)
+  end subroutine test_subblock_indices_even_right_mhd
+
+
+  @test
+  subroutine test_subblock_indices_odd_left_mhd_zero()
+    call set_name("get subblock indices (odd, left, MHD, with zero)")
+    idxs = get_subblock_index( &
+      variables=["v1", "00", "v2", "va", "T4"], odd=.true., edge="left" &
+    )
+    @assertEqual([3, 5], idxs)
+  end subroutine test_subblock_indices_odd_left_mhd_zero
+
+
+  @test
+  subroutine test_subblock_indices_even_left_mhd_zero()
+    call set_name("get subblock indices (even, left, MHD, with zero)")
+    idxs = get_subblock_index( &
+      variables=["v1", "00", "v7", "v2", "T4"], odd=.false., edge="left" &
+    )
+    @assertEqual([4, 6], idxs)
+  end subroutine test_subblock_indices_even_left_mhd_zero
+
+
+  @test
+  subroutine test_subblock_indices_odd_right_mhd_zero()
+    call set_name("get subblock indices (odd, right, MHD, with zero)")
+    idxs = get_subblock_index( &
+      variables=["v1", "00", "v2", "va", "T4"], odd=.true., edge="right" &
+    )
+    @assertEqual([19, 21], idxs)
+  end subroutine test_subblock_indices_odd_right_mhd_zero
+
+
+  @test
+  subroutine test_subblock_indices_even_right_mhd_zero()
+    call set_name("get subblock indices (even, right, MHD, with zero)")
+    idxs = get_subblock_index( &
+      variables=["v1", "00", "v7", "v2", "T4"], odd=.false., edge="right" &
+    )
+    @assertEqual([20, 22], idxs)
+  end subroutine test_subblock_indices_even_right_mhd_zero
+
+end module mod_test_indices

--- a/tests/unit_tests/mod_test_logging.pf
+++ b/tests/unit_tests/mod_test_logging.pf
@@ -59,4 +59,21 @@ contains
     call set_name("logging (logical -> str, false)")
     @assertEqual("False", str(.false.))
   end subroutine test_logical_to_str_false
+
+
+  @test
+   subroutine test_char_array_to_str_equal()
+     call set_name("logging (character array -> str, equal lengths)")
+     @assertEqual("[test1, test2, test3]", str(["test1", "test2", "test3"]))
+   end subroutine test_char_array_to_str_equal
+
+
+   @test
+   subroutine test_char_array_to_str_nequal()
+     character(len=9) :: teststring(3)
+
+     call set_name("logging (character array -> str, unequal lengths)")
+     teststring = [character(len=9) :: "test1", "test000", "test"]
+     @assertEqual("[test1, test000, test]", str(teststring))
+   end subroutine test_char_array_to_str_nequal
 end module mod_test_logging

--- a/tests/unit_tests/mod_test_valuechecks.pf
+++ b/tests/unit_tests/mod_test_valuechecks.pf
@@ -5,8 +5,6 @@ module mod_test_valuechecks
   use mod_check_values
   implicit none
 
-  character(len=10) :: test_names(5) = ["name1", "name2", "name3", "name4", "name5"]
-
 contains
 
 
@@ -205,38 +203,4 @@ contains
     @assertTrue(is_constant(array, tol=5.0d-3))
   end subroutine test_is_constant
 
-
-  @test
-   subroutine test_find_name_index()
-     call set_name("get name index from array")
-     @assertEqual(2, get_index("name2", test_names))
-   end subroutine test_find_name_index
-
-
-   @test
-   subroutine test_find_name_index_fail()
-     call set_name("get name index from array (fail)")
-     @assertEqual(0, get_index("unknown", test_names))
-   end subroutine test_find_name_index_fail
-
-
-   @test
-   subroutine test_find_name_indices()
-     call set_name("get name indices from array")
-     @assertEqual([3, 4], get_index(["name3", "name4"], test_names))
-   end subroutine test_find_name_indices
-
-
-   @test
-   subroutine test_find_name_indices_partial()
-     call set_name("get name indices from array (partial)")
-     @assertEqual([5, 0, 2], get_index(["name5", "test1", "name2"], test_names))
-   end subroutine test_find_name_indices_partial
-
-
-   @test
-   subroutine test_find_name_indices_fail()
-     call set_name("get name indices from array (fail)")
-     @assertEqual([0, 0, 0], get_index(["test1", "test2", "test3"], test_names))
-   end subroutine test_find_name_indices_fail
 end module mod_test_valuechecks

--- a/tests/unit_tests/mod_test_valuechecks.pf
+++ b/tests/unit_tests/mod_test_valuechecks.pf
@@ -1,8 +1,11 @@
 module mod_test_valuechecks
+  use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
   use mod_suite_utils
   use funit
   use mod_check_values
   implicit none
+
+  character(len=10) :: test_names(5) = ["name1", "name2", "name3", "name4", "name5"]
 
 contains
 
@@ -82,11 +85,11 @@ contains
 
   @test
   subroutine test_is_nan_real()
-    use mod_global_variables, only: NaN
-
+    real(dp)  :: NaN
     real(dp)  :: array(20)
 
     call set_name("check for NaN (real)")
+    NaN = ieee_value(NaN, ieee_quiet_nan)
     ! single value
     @assertTrue(is_NaN(NaN))
     @assertFalse(is_NaN(1.0d0))
@@ -99,11 +102,11 @@ contains
 
   @test
   subroutine test_is_nan_complex()
-    use mod_global_variables, only: NaN
-
+    real(dp)  :: NaN
     complex(dp)  :: array(20)
 
     call set_name("check for NaN (complex)")
+    NaN = ieee_value(NaN, ieee_quiet_nan)
     ! single value
     @assertFalse(is_NaN((1.0d0, 2.0d0)))
     @assertTrue(is_NaN(cmplx(1.0d0, NaN, kind=dp)))
@@ -201,4 +204,39 @@ contains
     array(15) = 2.5d-5
     @assertTrue(is_constant(array, tol=5.0d-3))
   end subroutine test_is_constant
+
+
+  @test
+   subroutine test_find_name_index()
+     call set_name("get name index from array")
+     @assertEqual(2, get_index("name2", test_names))
+   end subroutine test_find_name_index
+
+
+   @test
+   subroutine test_find_name_index_fail()
+     call set_name("get name index from array (fail)")
+     @assertEqual(0, get_index("unknown", test_names))
+   end subroutine test_find_name_index_fail
+
+
+   @test
+   subroutine test_find_name_indices()
+     call set_name("get name indices from array")
+     @assertEqual([3, 4], get_index(["name3", "name4"], test_names))
+   end subroutine test_find_name_indices
+
+
+   @test
+   subroutine test_find_name_indices_partial()
+     call set_name("get name indices from array (partial)")
+     @assertEqual([5, 0, 2], get_index(["name5", "test1", "name2"], test_names))
+   end subroutine test_find_name_indices_partial
+
+
+   @test
+   subroutine test_find_name_indices_fail()
+     call set_name("get name indices from array (fail)")
+     @assertEqual([0, 0, 0], get_index(["test1", "test2", "test3"], test_names))
+   end subroutine test_find_name_indices_fail
 end module mod_test_valuechecks

--- a/tests/unit_tests/mod_test_variables.pf
+++ b/tests/unit_tests/mod_test_variables.pf
@@ -56,15 +56,4 @@ contains
     @assertEqual(160, dim_matrix)
   end subroutine test_matrix_properties_mhd
 
-  @test
-  subroutine test_matrix_properties_mhd_selfgravity()
-    call set_name("matrix properties MHD (selfgravity)")
-    selfgravity = .true.
-    call set_matrix_properties(points=10)
-    @assertEqual(size(state_vector), 9)
-    @assertEqual(18, dim_subblock)
-    @assertEqual(36, dim_quadblock)
-    @assertEqual(180, dim_matrix)
-  end subroutine test_matrix_properties_mhd_selfgravity
-
 end module mod_test_variables

--- a/tests/unit_tests/mod_test_variables.pf
+++ b/tests/unit_tests/mod_test_variables.pf
@@ -1,5 +1,5 @@
 module mod_test_variables
-  use mod_global_variables, only: dp
+  use mod_global_variables
   use mod_suite_utils
   use funit
   implicit none
@@ -21,10 +21,7 @@ contains
 
   @test
   subroutine test_gamma()
-    use mod_global_variables, only: gamma, gamma_1, set_gamma
-
     call set_name("setting gamma")
-
     call set_gamma(5.0d0 / 3.0d0)
     @assertEqual(5.0d0 / 3.0d0, gamma, tolerance=TOL)
     @assertEqual(2.0d0 / 3.0d0, gamma_1, tolerance=TOL)
@@ -33,10 +30,7 @@ contains
 
   @test
   subroutine test_gamma_incompressible()
-    use mod_global_variables, only: gamma, incompressible, set_gamma
-
     call set_name("setting incompressible")
-
     incompressible = .true.
     call set_gamma(1.0d0)
     @assertGreaterThan(gamma, 1.0d5)
@@ -45,17 +39,32 @@ contains
 
   @test
   subroutine test_gridpts()
-    use mod_global_variables, only: &
-      gridpts, gauss_gridpts, dim_matrix, ef_gridpts, set_gridpts
-    integer, parameter :: gridpts_test = 11
-
     call set_name("setting gridpoints")
-
-    call set_gridpts(gridpts_test)
-    @assertEqual(gridpts_test, gridpts)
+    call set_gridpts(11)
+    @assertEqual(11, gridpts)
     @assertEqual(40, gauss_gridpts)
-    @assertEqual(176, dim_matrix)
     @assertEqual(21, ef_gridpts)
   end subroutine test_gridpts
+
+  @test
+  subroutine test_matrix_properties_mhd()
+    call set_name("matrix properties MHD")
+    call set_matrix_properties(points=10)
+    @assertEqual(size(state_vector), 8)
+    @assertEqual(16, dim_subblock)
+    @assertEqual(32, dim_quadblock)
+    @assertEqual(160, dim_matrix)
+  end subroutine test_matrix_properties_mhd
+
+  @test
+  subroutine test_matrix_properties_mhd_selfgravity()
+    call set_name("matrix properties MHD (selfgravity)")
+    selfgravity = .true.
+    call set_matrix_properties(points=10)
+    @assertEqual(size(state_vector), 9)
+    @assertEqual(18, dim_subblock)
+    @assertEqual(36, dim_quadblock)
+    @assertEqual(180, dim_matrix)
+  end subroutine test_matrix_properties_mhd_selfgravity
 
 end module mod_test_variables

--- a/tests/unit_tests/mod_test_variables.pf
+++ b/tests/unit_tests/mod_test_variables.pf
@@ -46,7 +46,7 @@ contains
   @test
   subroutine test_gridpts()
     use mod_global_variables, only: &
-      gridpts, gauss_gridpts, matrix_gridpts, ef_gridpts, set_gridpts
+      gridpts, gauss_gridpts, dim_matrix, ef_gridpts, set_gridpts
     integer, parameter :: gridpts_test = 11
 
     call set_name("setting gridpoints")
@@ -54,7 +54,7 @@ contains
     call set_gridpts(gridpts_test)
     @assertEqual(gridpts_test, gridpts)
     @assertEqual(40, gauss_gridpts)
-    @assertEqual(176, matrix_gridpts)
+    @assertEqual(176, dim_matrix)
     @assertEqual(21, ef_gridpts)
   end subroutine test_gridpts
 


### PR DESCRIPTION
## PR description
This PR introduces a dynamic state vector instead of a length-8 hardcoded vector with perturbed variables. 

- separate module `mod_get_indices` added with index retrieval functions
- boundary conditions: indices are no longer hardcoded but retrieved based on the state vector variable.
- refactored `matrix_gridpts` to `dim_matrix`

