### PR TITLE
Introduce a dedicated logger object

### DIFF
--- a/src/boundaries/mod_boundary_manager.f08
+++ b/src/boundaries/mod_boundary_manager.f08
@@ -1,6 +1,6 @@
 module mod_boundary_manager
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_matrix_structure, only: matrix_t
   use mod_settings, only: settings_t
   implicit none

--- a/src/boundaries/smod_essential_boundaries.f08
+++ b/src/boundaries/smod_essential_boundaries.f08
@@ -198,9 +198,8 @@ contains
       diagonal_factor = (0.0d0, 0.0d0)
     else
       diagonal_factor = NaN
-      call log_message( &
-        "get_diagonal_factor: invalid or empty matrix label: " // matrix%get_label(), &
-        level="error" &
+      call logger%error( &
+        "get_diagonal_factor: invalid or empty matrix label: " // matrix%get_label() &
       )
     end if
   end function get_diagonal_factor

--- a/src/boundaries/smod_natural_boundaries.f08
+++ b/src/boundaries/smod_natural_boundaries.f08
@@ -155,7 +155,7 @@ contains
       ! plus one here
       weight = 1.0d0
     else
-      call log_message("natural bounds: invalid edge argument " // edge, level="error")
+      call logger%error("natural bounds: invalid edge argument " // edge)
     end if
 
     ! set the basis functions

--- a/src/dataIO/mod_console.f08
+++ b/src/dataIO/mod_console.f08
@@ -29,7 +29,7 @@ contains
     character(len=57)      :: spaces_v = ""
     integer :: i
 
-    if (logger%get_logging_level() == 0) return
+    if (logger%get_logging_level() <= 1) return
 
     logo(1) = " __       ________  ________   _______   __          ___     __________ "
     logo(2) = "|  |     |   ____ \|   ____ \ /   _   \ |  |        /   \   |   ______ \"
@@ -57,7 +57,7 @@ contains
   subroutine print_console_info(settings)
     type(settings_t), intent(in) :: settings
 
-    if (logger%get_logging_level() == 0) return
+    if (logger%get_logging_level() <= 1) return
 
     call logger%info("---------------------------------------------")
     call logger%disable_prefix()

--- a/src/dataIO/mod_console.f08
+++ b/src/dataIO/mod_console.f08
@@ -1,6 +1,7 @@
 module mod_console
-  use mod_global_variables
-  use mod_logging, only: log_message, override_prefix_to_false, str, exp_fmt
+  use mod_global_variables, only: str_len
+  use mod_settings, only: settings_t
+  use mod_logging, only: logger, str, exp_fmt
   implicit none
 
   private
@@ -28,9 +29,7 @@ contains
     character(len=57)      :: spaces_v = ""
     integer :: i
 
-    if (logging_level <= 1) then
-      return
-    end if
+    if (logger%get_logging_level() == 0) return
 
     logo(1) = " __       ________  ________   _______   __          ___     __________ "
     logo(2) = "|  |     |   ____ \|   ____ \ /   _   \ |  |        /   \   |   ______ \"
@@ -46,8 +45,7 @@ contains
 
     call print_whitespace(1)
     do i = 1, size(logo)
-      call paint_string(spaces_logo // trim(logo(i)), "cyan", logo(i))
-      write(*, *) trim(adjustl(logo(i)))
+      write(*, *) paint_string(spaces_logo // trim(logo(i)), "cyan")
     end do
     call print_whitespace(2)
   end subroutine print_logo
@@ -57,156 +55,22 @@ contains
   !> Prints various console messages showing geometry, grid parameters,
   !! equilibrium parameters etc. Only for logging level "info" or above.
   subroutine print_console_info(settings)
-    use mod_global_variables
-    use mod_equilibrium_params, only: k2, k3
-    use mod_settings, only: settings_t
-
     type(settings_t), intent(in) :: settings
 
-    if (logging_level <= 1) then
-      return
-    end if
+    if (logger%get_logging_level() == 0) return
 
-    call log_message("---------------------------------------------")
+    call logger%info("---------------------------------------------")
+    call logger%disable_prefix()
 
-    ! we temporarily force the use of logging prefix to false
-    override_prefix_to_false = .true.
+    call log_grid_info(settings)
+    call log_equilibrium_info(settings)
+    call log_physics_info(settings)
+    call log_solver_info(settings)
+    call log_io_info(settings)
 
-    call log_message("              << Grid settings >>")
-    call log_message("geometry           : " // settings%grid%get_geometry())
-    call log_message("grid start         : " // str(settings%grid%get_grid_start()))
-    call log_message("grid end           : " // str(settings%grid%get_grid_end()))
-    call log_message("gridpoints (base)  : " // str(settings%grid%get_gridpts()))
-    call log_message("gridpoints (Gauss) : " // str(settings%grid%get_gauss_gridpts()))
-    call log_message("gridpoints (matrix): " // str(settings%dims%get_dim_matrix()))
-
-    call log_message("          << Equilibrium settings >>")
-    call log_message( &
-      "equilibrium    : " // settings%equilibrium%get_equilibrium_type() &
-    )
-    call log_message("wave number k2 : " // str(k2))
-    call log_message("wave number k3 : " // str(k3))
-    call log_message("default params : " // str(settings%equilibrium%use_defaults))
-
-    call log_message("            << Physics settings >>")
-    call log_message("flow               : " // str(settings%physics%flow%is_enabled()))
-    call log_message( &
-      "external gravity   : " // str(settings%physics%gravity%is_enabled()) &
-    )
-
-    call log_message( &
-      "radiative cooling  : " // str(settings%physics%cooling%is_enabled()) &
-    )
-    if (settings%physics%cooling%is_enabled()) then
-      call log_message( &
-        "    cooling curve : " &
-        // trim(adjustl(settings%physics%cooling%get_cooling_curve())) &
-      )
-    end if
-
-    call log_message( &
-      "thermal conduction : " // str(settings%physics%conduction%is_enabled()) &
-    )
-    if (settings%physics%conduction%is_enabled()) then
-      if (settings%physics%conduction%has_fixed_tc_para()) then
-        call log_message( &
-          "    fixed parallel value : " &
-          // str(settings%physics%conduction%get_fixed_tc_para()) &
-        )
-      end if
-      if (settings%physics%conduction%has_fixed_tc_perp()) then
-        call log_message( &
-          "    fixed perpendicular value : " &
-          // str(settings%physics%conduction%get_fixed_tc_perp()) &
-        )
-      end if
-    end if
-    call log_message( &
-      "resistivity        : " // str(settings%physics%resistivity%is_enabled()) &
-    )
-    if (settings%physics%resistivity%has_fixed_resistivity()) then
-      call log_message( &
-        "    fixed eta value : " &
-        // str(settings%physics%resistivity%get_fixed_resistivity()) &
-      )
-    end if
-
-    call log_message( &
-      "viscosity          : " // str(settings%physics%viscosity%is_enabled()) &
-    )
-    if (settings%physics%viscosity%is_enabled()) then
-      call log_message( &
-        "    viscosity value : " &
-        // str(settings%physics%viscosity%get_viscosity_value()) &
-      )
-      call log_message( &
-        "    viscous heating : " &
-        // str(settings%physics%viscosity%has_viscous_heating()) &
-      )
-    end if
-
-    call log_message("hall mhd           : " // str(settings%physics%hall%is_enabled()))
-    if (settings%physics%hall%is_enabled()) then
-      call log_message( &
-        "    by substitution   : " &
-        // str(settings%physics%hall%is_using_substitution()) &
-      )
-      call log_message( &
-        "    electron fraction : " &
-        // str(settings%physics%hall%get_electron_fraction()) &
-      )
-      call log_message( &
-        "    electron inertia  : " &
-        // str(settings%physics%hall%has_electron_inertia()) &
-      )
-    end if
-
-    call log_message("            << Solver settings >>")
-    call log_message("solver      : " // settings%solvers%get_solver())
-    if (settings%solvers%get_solver() == "arnoldi") then
-      call log_message("ARPACK mode : " // settings%solvers%get_arpack_mode())
-      if (settings%solvers%get_arpack_mode() == "shift-invert") then
-        call log_message("sigma : " // str(settings%solvers%sigma))
-      end if
-      call log_message( &
-        "number of eigenvalues : " // str(settings%solvers%number_of_eigenvalues) &
-      )
-      call log_message( &
-        "which eigenvalues     : " // settings%solvers%which_eigenvalues &
-      )
-      call log_message("maxiter               : " // str(settings%solvers%maxiter))
-      call log_message( &
-        "tolerance             : " // str(settings%solvers%tolerance, exp_fmt) &
-      )
-    end if
-    if (settings%solvers%get_solver() == "inverse-iteration") then
-      call log_message("sigma     : " // str(settings%solvers%sigma))
-      call log_message("maxiter   : " // str(settings%solvers%maxiter))
-      call log_message("tolerance : " // str(settings%solvers%tolerance, exp_fmt))
-    end if
-
-    call log_message("            << DataIO settings >>")
-    call log_message("datfile name         : " // settings%io%get_basename_datfile())
-    call log_message("output folder        : " // settings%io%get_output_folder())
-    call log_message("write matrices       : " // str(settings%io%write_matrices))
-    call log_message("write eigenvectors   : " // str(settings%io%write_eigenvectors))
-    call log_message("write residuals      : " // str(settings%io%write_residuals))
-    call log_message("write eigenfunctions : " // str(settings%io%write_eigenfunctions))
-    call log_message( &
-      "write derived eigenfunctions : " &
-      // str(settings%io%write_derived_eigenfunctions) &
-    )
-    call log_message( &
-      "write eigenfunction subset : " // str(settings%io%write_ef_subset) &
-    )
-    if (settings%io%write_ef_subset) then
-      call log_message("    subset center : " // str(settings%io%ef_subset_center))
-      call log_message("    subset radius : " // str(settings%io%ef_subset_radius))
-    end if
-    call log_message("---------------------------------------------")
+    call logger%info("---------------------------------------------")
+    call logger%enable_prefix()
     call print_whitespace(1)
-    ! reset override
-    override_prefix_to_false = .false.
   end subroutine print_console_info
 
 
@@ -217,13 +81,197 @@ contains
     integer, intent(in) :: lines
     integer :: i
 
-    if (logging_level >= 1) then
+    if (logger%get_logging_level() >= 1) then
       do i = 1, lines
         write(*, *) ""
       end do
     end if
   end subroutine print_whitespace
 
-  ! LCOV_EXCL_STOP
+
+  subroutine log_grid_info(settings)
+    type(settings_t), intent(in) :: settings
+
+    call logger%info("              << Grid settings >>")
+    call logger%info("geometry           : " // settings%grid%get_geometry())
+    call logger%info("grid start         : " // str(settings%grid%get_grid_start()))
+    call logger%info("grid end           : " // str(settings%grid%get_grid_end()))
+    call logger%info("gridpoints (base)  : " // str(settings%grid%get_gridpts()))
+    call logger%info("gridpoints (Gauss) : " // str(settings%grid%get_gauss_gridpts()))
+    call logger%info("gridpoints (matrix): " // str(settings%dims%get_dim_matrix()))
+  end subroutine log_grid_info
+
+
+  subroutine log_equilibrium_info(settings)
+    use mod_equilibrium_params, only: k2, k3
+    type(settings_t), intent(in) :: settings
+
+    call logger%info("          << Equilibrium settings >>")
+    call logger%info("equilibrium : " // settings%equilibrium%get_equilibrium_type())
+    call logger%info("k2          : " // str(k2))
+    call logger%info("k3          : " // str(k3))
+    call logger%info("use defaults: " // str(settings%equilibrium%use_defaults))
+  end subroutine log_equilibrium_info
+
+
+  subroutine log_physics_info(settings)
+    type(settings_t), intent(in) :: settings
+
+    call logger%info("            << Physics settings >>")
+    call logger%info("physics type : " // settings%get_physics_type())
+    call logger%info("gamma        : " // str(settings%physics%get_gamma()))
+    call log_flow_info()
+    call log_gravity_info()
+    call log_cooling_info()
+    call log_parallel_conduction_info()
+    call log_perpendicular_conduction_info()
+    call log_resistivity_info()
+    call log_viscosity_info()
+    call log_hall_info()
+
+    contains
+
+    subroutine log_flow_info()
+      logical :: flow
+      flow = settings%physics%flow%is_enabled()
+      call logger%info("flow                     : " // str(flow))
+    end subroutine log_flow_info
+
+    subroutine log_gravity_info()
+      logical :: gravity
+      gravity = settings%physics%gravity%is_enabled()
+      call logger%info("external gravity         : " // str(gravity))
+    end subroutine log_gravity_info
+
+    subroutine log_cooling_info()
+      logical :: cooling
+      cooling = settings%physics%cooling%is_enabled()
+      call logger%info("radiative cooling        : " // str(cooling))
+      if (.not. cooling) return
+      call logger%info("  cooling curve          : " // &
+        trim(adjustl(settings%physics%cooling%get_cooling_curve())) &
+      )
+    end subroutine log_cooling_info
+
+    subroutine log_parallel_conduction_info()
+      logical :: tc_para
+      tc_para = settings%physics%conduction%has_parallel_conduction()
+      call logger%info("parallel conduction      : " // str(tc_para))
+      if (.not. tc_para) return
+      if (settings%physics%conduction%has_fixed_tc_para()) then
+        call logger%info("  fixed value            : " // &
+          str(settings%physics%conduction%get_fixed_tc_para(), fmt=exp_fmt) &
+        )
+      end if
+    end subroutine log_parallel_conduction_info
+
+    subroutine log_perpendicular_conduction_info()
+      logical :: tc_perp
+      tc_perp = settings%physics%conduction%has_perpendicular_conduction()
+      call logger%info("perpendicular conduction : " // str(tc_perp))
+      if (.not. tc_perp) return
+      if (settings%physics%conduction%has_fixed_tc_perp()) then
+        call logger%info("  fixed value            : " // &
+          str(settings%physics%conduction%get_fixed_tc_perp(), fmt=exp_fmt) &
+        )
+      end if
+    end subroutine log_perpendicular_conduction_info
+
+    subroutine log_resistivity_info()
+      logical :: resistivity
+      resistivity = settings%physics%resistivity%is_enabled()
+      call logger%info("resistivity              : " // str(resistivity))
+      if (.not. resistivity) return
+      if (settings%physics%resistivity%has_fixed_resistivity()) then
+        call logger%info("  fixed eta value        : " // &
+          str(settings%physics%resistivity%get_fixed_resistivity(), fmt=exp_fmt) &
+        )
+      end if
+    end subroutine log_resistivity_info
+
+    subroutine log_viscosity_info()
+      logical :: viscosity
+      viscosity = settings%physics%viscosity%is_enabled()
+      call logger%info("viscosity                : " // str(viscosity))
+      if (.not. viscosity) return
+      call logger%info( &
+        "  viscosity value        : " // &
+        str(settings%physics%viscosity%get_viscosity_value()) &
+      )
+      call logger%info( &
+        "  viscous heating        : " // &
+        str(settings%physics%viscosity%has_viscous_heating()) &
+      )
+    end subroutine log_viscosity_info
+
+    subroutine log_hall_info()
+      logical :: hall
+      hall = settings%physics%hall%is_enabled()
+      call logger%info("hall mhd                 : " // str(hall))
+      if (.not. hall) return
+      call logger%info( &
+        "  by substitution        : " // &
+        str(settings%physics%hall%is_using_substitution()) &
+      )
+      call logger%info( &
+        "  electron fraction      : " // &
+        str(settings%physics%hall%get_electron_fraction()) &
+      )
+      call logger%info( &
+        "  electron inertia       : " // &
+        str(settings%physics%hall%has_electron_inertia()) &
+      )
+    end subroutine log_hall_info
+  end subroutine log_physics_info
+
+
+  subroutine log_solver_info(settings)
+    type(settings_t), intent(in) :: settings
+
+    call logger%info("            << Solver settings >>")
+    call logger%info("solver      : " // settings%solvers%get_solver())
+    select case(settings%solvers%get_solver())
+    case("arnoldi")
+      call logger%info("ARPACK mode : " // settings%solvers%get_arpack_mode())
+      call logger%info( &
+        "# eigenvalues : " // str(settings%solvers%number_of_eigenvalues) &
+      )
+      call logger%info("which eigenvalues : " // settings%solvers%which_eigenvalues)
+      call logger%info("maxiter : " // str(settings%solvers%maxiter))
+      call logger%info("ncv     : " // str(settings%solvers%ncv))
+      if (settings%solvers%get_arpack_mode() == "shift-invert") then
+        call logger%info("sigma : " // str(settings%solvers%sigma))
+      end if
+      call logger%info("tolerance : " // str(settings%solvers%tolerance, exp_fmt))
+    case("inverse-iteration")
+      call logger%info("sigma     : " // str(settings%solvers%sigma))
+      call logger%info("maxiter   : " // str(settings%solvers%maxiter))
+      call logger%info("tolerance : " // str(settings%solvers%tolerance, exp_fmt))
+    end select
+  end subroutine log_solver_info
+
+
+  subroutine log_io_info(settings)
+    type(settings_t), intent(in) :: settings
+
+    call logger%info("            << DataIO settings >>")
+    call logger%info("datfile name         : " // settings%io%get_basename_datfile())
+    call logger%info("output folder        : " // settings%io%get_output_folder())
+    call logger%info("write matrices       : " // str(settings%io%write_matrices))
+    call logger%info("write eigenvectors   : " // str(settings%io%write_eigenvectors))
+    call logger%info("write residuals      : " // str(settings%io%write_residuals))
+    call logger%info("write eigenfunctions : " // str(settings%io%write_eigenfunctions))
+    call logger%info( &
+      "write derived eigenfunctions : " &
+      // str(settings%io%write_derived_eigenfunctions) &
+    )
+    call logger%info( &
+      "write eigenfunction subset : " // str(settings%io%write_ef_subset) &
+    )
+    if (settings%io%write_ef_subset) then
+      call logger%info("    subset center : " // str(settings%io%ef_subset_center))
+      call logger%info("    subset radius : " // str(settings%io%ef_subset_radius))
+    end if
+  end subroutine log_io_info
 
 end module mod_console

--- a/src/dataIO/mod_exceptions.f08
+++ b/src/dataIO/mod_exceptions.f08
@@ -69,15 +69,11 @@ contains
   !! is printed to the console and program execution
   !! is terminated.
   subroutine on_exception_raised(msg)
-    use mod_global_variables, only: str_len
     use mod_painting, only: paint_string
-
     !> message to print to the console when exception is raised
     character(len=*), intent(in) :: msg
-    character(len=3*str_len) :: msg_painted
 
-    call paint_string(" ERROR   | " // msg, "red", msg_painted)
-    write(*, *) trim(msg_painted)
+    write(*, *) paint_string(msg, "red")
     error stop
   end subroutine on_exception_raised
   ! LCOV_EXCL_STOP

--- a/src/dataIO/mod_exceptions.f08
+++ b/src/dataIO/mod_exceptions.f08
@@ -73,7 +73,7 @@ contains
     !> message to print to the console when exception is raised
     character(len=*), intent(in) :: msg
 
-    write(*, *) paint_string(msg, "red")
+    write(*, *) paint_string(" ERROR   | " // msg, "red")
     error stop
   end subroutine on_exception_raised
   ! LCOV_EXCL_STOP

--- a/src/dataIO/mod_logging.f08
+++ b/src/dataIO/mod_logging.f08
@@ -100,7 +100,7 @@ contains
   end subroutine warning
 
 
-  subroutine info(this, msg)
+  subroutine info(this, msg)  ! LCOV_EXCL_START
     class(logger_t), intent(in) :: this
     character(len=*), intent(in) :: msg
     character(:), allocatable :: msg_raised
@@ -112,10 +112,10 @@ contains
       msg_raised = "         | " // msg
     end if
     write(*, *) msg_raised
-  end subroutine info
+  end subroutine info  ! LCOV_EXCL_STOP
 
 
-  subroutine debug(this, msg)
+  subroutine debug(this, msg)  ! LCOV_EXCL_START
     class(logger_t), intent(in) :: this
     character(len=*), intent(in) :: msg
     character(:), allocatable :: msg_raised
@@ -127,7 +127,7 @@ contains
       msg_raised = "         | " // msg
     end if
     write(*, *) paint_string(msg_raised, "green")
-  end subroutine debug
+  end subroutine debug  ! LCOV_EXCL_STOP
 
 
   pure function logical_tostring(boolean) result(string)

--- a/src/dataIO/mod_logging.f08
+++ b/src/dataIO/mod_logging.f08
@@ -1,219 +1,219 @@
-! =============================================================================
-!> Main handler for console print statements. The level of information
-!! printed to the console depends on the corresponding global variable
-!! called <tt>logging_level</tt> defined in the parfile.
-!! @note Values for <tt>logging_level</tt> can be set to
-!!
-!! - If <tt>logging_level = 0</tt>: only critical errors are printed, everything else
-!!                                  is suppressed.
-!! - If <tt>logging_level = 1</tt>: only errors and warnings are printed.
-!! - If <tt>logging_level = 2</tt>: errors, warnings and info messages are printed.
-!!                                  This is the default value.
-!! - If <tt>logging_level = 3+</tt>: prints all of the above,
-!!                                   including debug messages. @endnote
 module mod_logging
-  use mod_global_variables, only: logging_level, str_len
+  use mod_global_variables, only: dp
   use mod_painting, only: paint_string
   implicit none
 
-  !> exponential format
-  character(8), parameter    :: exp_fmt = '(e20.8)'
-  !> shorter float format
-  character(8), parameter    :: dp_fmt = '(f20.8)'
-  !> integer format
-  character(4), parameter    :: int_fmt  = '(i8)'
-  !> a convenient "tostring" interface, used for easy console writing
-  interface str
-    module procedure logical_tostr
-    module procedure int_tostr
-    module procedure float_tostr
-    module procedure complex_tostr
-    module procedure character_arr_tostr
-  end interface str
-
-  !> logical used to (locally) force a prefix override
-  logical :: override_prefix_to_false = .false.
-
   private
 
-  public :: log_message
+  !> exponential format
+  character(8), parameter :: exp_fmt = "(e20.8)"
+  !> shorter float format
+  character(8), parameter :: dp_fmt = "(f20.8)"
+  !> integer format
+  character(4), parameter :: int_fmt  = "(i8)"
+
+  interface str
+    module procedure logical_tostring
+    module procedure integer_tostring
+    module procedure real_tostring
+    module procedure complex_tostring
+    module procedure character_array_tostring
+  end interface str
+
+  type, private :: logger_t
+    integer, private :: logging_level
+    logical, private :: use_prefix
+
+  contains
+
+    procedure, public :: error
+    procedure, public :: warning
+    procedure, public :: info
+    procedure, public :: debug
+
+    procedure, public :: initialise
+    procedure, public :: set_logging_level
+    procedure, public :: get_logging_level
+    procedure, public :: enable_prefix
+    procedure, public :: disable_prefix
+
+  end type logger_t
+
+  type(logger_t), public :: logger
+
   public :: str
   public :: exp_fmt, dp_fmt, int_fmt
-  public :: override_prefix_to_false
 
 contains
 
+  pure subroutine initialise(this)
+    class(logger_t), intent(inout) :: this
+    this%logging_level = 2
+    this%use_prefix = .true.
+  end subroutine initialise
 
-  !> Logs messages to the console. Every message will be prepended by
-  !! [  LEVEL  ] to indicate its type. If this is not desired, set
-  !! <tt>use_prefix = .false.</tt>.
-  !! @warning An error is thrown if a wrong level is passed. @endwarning
-  !! @note The argument <tt>level</tt> can be 'error', 'warning', 'info' or 'debug'.
-  !!       The 'error' level corresponds to throwing a critical error and
-  !!       stops code execution.
-  !!       Error messages are printed in red, warnings in yellow, info messages have
-  !!       default colouring and debug messages are in green.
-  subroutine log_message(msg, level, use_prefix) ! LCOV_EXCL_START
+
+  pure subroutine set_logging_level(this, logging_level)
+    class(logger_t), intent(inout) :: this
+    integer, intent(in) :: logging_level
+    this%logging_level = logging_level
+  end subroutine set_logging_level
+
+
+  pure integer function get_logging_level(this) result(logging_level)
+    class(logger_t), intent(in) :: this
+    logging_level = this%logging_level
+  end function get_logging_level
+
+
+  pure subroutine enable_prefix(this)
+    class(logger_t), intent(inout) :: this
+    this%use_prefix = .true.
+  end subroutine enable_prefix
+
+
+  pure subroutine disable_prefix(this)
+    class(logger_t), intent(inout) :: this
+    this%use_prefix = .false.
+  end subroutine disable_prefix
+
+
+  subroutine error(this, msg)
     use mod_exceptions, only: raise_exception
 
-    !> the message to print to the console
-    character(len=*), intent(in)  :: msg
-    !> the level (severity) of the message, default is <tt>"info"</tt>
-    character(len=*), intent(in), optional  :: level
-    !> prefixes message type to string, default is <tt>.true.</tt>
-    logical, intent(in), optional :: use_prefix
+    class(logger_t), intent(in) :: this
+    character(len=*), intent(in) :: msg
+    character(:), allocatable :: msg_raised
 
-    ! need a bit more room here, we trim anyway when printing
-    character(len=2*str_len) :: msg_painted
-    character(:), allocatable :: loglevel
-    logical :: add_prefix
-
-    add_prefix = .true.
-    if (present(use_prefix)) then
-      add_prefix = use_prefix
-    end if
-    ! override prefix if desired
-    if (override_prefix_to_false) then
-      add_prefix = .false.
-    end if
-    if (present(level)) then
-      loglevel = level
+    if (this%use_prefix) then
+      msg_raised = " ERROR   | " // msg
     else
-      loglevel = "info"
+      msg_raised = "         | " // msg
     end if
-
-    select case(loglevel)
-    case("error")
-      call raise_exception(msg)
-    case("warning")
-      if (logging_level >= 1) then
-        if (add_prefix) then
-          call paint_string(" WARNING | " // msg, "yellow", msg_painted)
-        else
-          call paint_string("           " // msg, "yellow", msg_painted)
-        end if
-        write(*, *) trim(msg_painted)
-      end if
-    case("info")
-      if (logging_level >= 2) then
-        if (add_prefix) then
-          write(*, *) " INFO    | " // trim(msg)
-        else
-          write(*, *) "           " // trim(msg)
-        end if
-      end if
-    case("debug")
-      if (logging_level >=3) then
-        if (add_prefix) then
-          call paint_string(" DEBUG   | " // msg, "green", msg_painted)
-        else
-          call paint_string("         | " // msg, "green", msg_painted)
-        end if
-        write(*, *) trim(msg_painted)
-      end if
-    case default
-      call raise_exception( &
-        "argument 'level' should be 'error', 'warning', 'info' or 'debug'" &
-      )
-      error stop
-    end select
-  end subroutine log_message ! LCOV_EXCL_STOP
+    call raise_exception(msg_raised)
+  end subroutine error
 
 
-  !> Converts a given logical to a string "True" or "False".
-  function logical_tostr(boolean) result(result_str)
-    !> logical to convert
+  subroutine warning(this, msg)
+    class(logger_t), intent(in) :: this
+    character(len=*), intent(in) :: msg
+    character(:), allocatable :: msg_raised
+
+    if (.not. this%logging_level >= 1) return
+    if (this%use_prefix) then
+      msg_raised = " WARNING | " // msg
+    else
+      msg_raised = "         | " // msg
+    end if
+    write(*, *) paint_string(msg_raised, "yellow")
+  end subroutine warning
+
+
+  subroutine info(this, msg)
+    class(logger_t), intent(in) :: this
+    character(len=*), intent(in) :: msg
+    character(:), allocatable :: msg_raised
+
+    if (.not. this%logging_level >= 2) return
+    if (this%use_prefix) then
+      msg_raised = " INFO    | " // msg
+    else
+      msg_raised = "         | " // msg
+    end if
+    write(*, *) msg_raised
+  end subroutine info
+
+
+  subroutine debug(this, msg)
+    class(logger_t), intent(in) :: this
+    character(len=*), intent(in) :: msg
+    character(:), allocatable :: msg_raised
+
+    if (.not. this%logging_level >= 3) return
+    if (this%use_prefix) then
+      msg_raised = " DEBUG   | " // msg
+    else
+      msg_raised = "         | " // msg
+    end if
+    write(*, *) paint_string(msg_raised, "green")
+  end subroutine debug
+
+
+  pure function logical_tostring(boolean) result(string)
     logical, intent(in) :: boolean
-    !> return string, made allocatable so it has same length as input
-    character(:), allocatable :: result_str
-
+    character(:), allocatable :: string
     if (boolean) then
-      result_str = "True"
+      string = "True"
     else
-      result_str = "False"
+      string = "False"
     end if
-  end function logical_tostr
+  end function logical_tostring
 
 
-  !> Converts a given integer to a string, the default format is "i8".
-  function int_tostr(value, fmt) result(result_str)
-    !> integer to convert
-    integer, intent(in) :: value
-    !> optional format used for writing, default "i8"
-    character(len=*), intent(in), optional  :: fmt
-    !> return string, made allocatable so it has same length as input
-    character(:), allocatable :: result_str
-    character(len=20) :: format, char_log
+  pure function integer_tostring(int_value, fmt) result(string)
+    integer, intent(in) :: int_value
+    character(len=*), intent(in), optional :: fmt
+    character(len=20) :: tmp
+    character(:), allocatable :: fmt_string
+    character(:), allocatable :: string
 
     if (present(fmt)) then
-      format = "(" // trim(fmt) // ")"
+      fmt_string = "(" // trim(fmt) // ")"
     else
-      format = int_fmt
+      fmt_string = int_fmt
     end if
-    write(char_log, format) value
-    result_str = trim(adjustl(char_log))
-  end function int_tostr
+    write(tmp, fmt_string) int_value
+    string = trim(adjustl(tmp))
+  end function integer_tostring
 
 
-  !> Converts a given float to a string, the default format is "f20.8".
-  function float_tostr(value, fmt) result(result_str)
-    use mod_global_variables, only: dp
-
-    !> float to convert
-    real(dp), intent(in)  :: value
-    !> optional format use for writing, default "f20.8"
-    character(len=*), intent(in), optional  :: fmt
-    !> return string, made allocatable so it has same length as input
-    character(:), allocatable :: result_str
-    character(len=20) :: format, char_log
+  pure function real_tostring(real_value, fmt) result(string)
+    real(dp), intent(in) :: real_value
+    character(len=*), intent(in), optional :: fmt
+    character(len=20) :: tmp
+    character(:), allocatable :: fmt_string
+    character(:), allocatable :: string
 
     if (present(fmt)) then
-      format = "(" // trim(fmt) // ")"
+      fmt_string = "(" // trim(fmt) // ")"
     else
-      format = dp_fmt
+      fmt_string = dp_fmt
     end if
-    write(char_log, format) value
-    result_str = trim(adjustl(char_log))
-  end function float_tostr
+    write(tmp, fmt_string) real_value
+    string = trim(adjustl(tmp))
+  end function real_tostring
 
 
-  !> Converts a given complex number to a string, the default format is "f20.8".
-  !! This will be printed in the form xxxx + xxxxi.
-  function complex_tostr(value, fmt) result(result_str)
-    use mod_global_variables, only: dp
-
-    !> complex to convert
-    complex(dp), intent(in) :: value
-    !> optional format use for writing, default "f20.8"
-    character(len=*), intent(in), optional  :: fmt
-    !> return string, made allocatable so it has same length as input
-    character(:), allocatable :: result_str
-    character(len=20) :: format, char_log, char_log2
+  pure function complex_tostring(complex_value, fmt) result(string)
+    complex(dp), intent(in) :: complex_value
+    character(len=*), intent(in), optional :: fmt
+    character(:), allocatable :: string
+    character(:), allocatable :: fmt_string
+    character(len=20) :: str_real, str_imag
 
     if (present(fmt)) then
-      format = "(" // trim(fmt) // ")"
+      fmt_string = "(" // trim(fmt) // ")"
     else
-      format = "(f18.8)"
+      fmt_string = "(f18.8)"
     end if
-    write(char_log, format) real(value)
-    write(char_log2, '(SP,' // format // ',"i")') aimag(value)
-    result_str = trim(adjustl(char_log)) // trim(adjustl(char_log2))
-  end function complex_tostr
+    write(str_real, fmt_string) real(complex_value)
+    write(str_imag, "(SP," // fmt_string // ",'i')") aimag(complex_value)
+    string = trim(adjustl(str_real)) // trim(adjustl(str_imag))
+  end function complex_tostring
 
 
-  !> Converts an array of characters to a string.
-  function character_arr_tostr(array) result(result_str)
+  pure function character_array_tostring(array) result(string)
     !> the array to convert
     character(len=*), intent(in)  :: array(:)
     !> returned result, trimmed
-    character(:), allocatable :: result_str
+    character(:), allocatable :: string
     integer :: i
 
-    result_str = "["
+    string = "["
     do i = 1, size(array)
-      result_str = result_str // trim(array(i)) // ", "
+      string = string // trim(array(i)) // ", "
     end do
-    result_str = result_str(:len(result_str) - 2) // "]"
-  end function character_arr_tostr
+    string = string(:len(string) - 2) // "]"
+  end function character_array_tostring
 
 end module mod_logging

--- a/src/dataIO/mod_logging.f08
+++ b/src/dataIO/mod_logging.f08
@@ -26,7 +26,7 @@ module mod_logging
 
   contains
 
-    procedure, public :: error
+    procedure, nopass, public :: error
     procedure, public :: warning
     procedure, public :: info
     procedure, public :: debug
@@ -78,19 +78,10 @@ contains
   end subroutine disable_prefix
 
 
-  subroutine error(this, msg)
+  subroutine error(msg)
     use mod_exceptions, only: raise_exception
-
-    class(logger_t), intent(in) :: this
     character(len=*), intent(in) :: msg
-    character(:), allocatable :: msg_raised
-
-    if (this%use_prefix) then
-      msg_raised = " ERROR   | " // msg
-    else
-      msg_raised = "         | " // msg
-    end if
-    call raise_exception(msg_raised)
+    call raise_exception(msg)
   end subroutine error
 
 

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -100,7 +100,7 @@ contains
 
     real(dp)  :: b01_array(size(B_field % B02))
     character(len=str_len_arr)    :: param_names(34), equil_names(32)
-    character(len=str_len) :: geometry
+    character(len=str_len) :: geometry, equilibrium_type
     character(len=2*str_len_arr)  :: unit_names(12)
     real(dp), allocatable         :: residuals(:)
     integer                       :: i
@@ -140,13 +140,14 @@ contains
 
     ! need str_len for now to ensure datfile reading compatibility
     geometry = settings%grid%get_geometry()
+    equilibrium_type = settings%equilibrium%get_equilibrium_type()
     ! First we write all header information
     write(dat_fh) "legolas_version", LEGOLAS_VERSION
     write(dat_fh) str_len, str_len_arr, geometry, settings%grid%get_grid_start(), &
       settings%grid%get_grid_end(), settings%grid%get_gridpts(), &
       settings%grid%get_gauss_gridpts(), settings%dims%get_dim_matrix(), &
       settings%grid%get_ef_gridpts(), settings%physics%get_gamma(), &
-      settings%equilibrium%get_equilibrium_type(), settings%io%write_eigenfunctions, &
+      equilibrium_type, settings%io%write_eigenfunctions, &
       settings%io%write_derived_eigenfunctions, settings%io%write_matrices, &
       settings%io%write_eigenvectors, settings%io%write_residuals, &
       settings%io%write_ef_subset, settings%io%ef_subset_center, &

--- a/src/dataIO/mod_painting.f08
+++ b/src/dataIO/mod_painting.f08
@@ -2,7 +2,6 @@
 !> This module handles formatting of terminal-printed strings.
 !! Contains subroutines to colourise strings.
 module mod_painting
-  use mod_global_variables, only: str_len
   implicit none
 
   !> escape character for logging
@@ -23,9 +22,6 @@ module mod_painting
   !> grey ANSI colour sequence
   character(len=*), parameter :: grey = esc // "[90m"
 
-  !> formatting used in logging
-  character(:), allocatable   :: fmt
-
   private
 
   public :: paint_string
@@ -38,13 +34,14 @@ contains
   !! returns a new string with ANSI escape sequences prepended
   !! and appended. If the 'colour' argument is not known, simply
   !! returns the string itself.
-  subroutine paint_string(msg, colour, msg_painted)
+  pure function paint_string(msg, colour) result(msg_painted)
     !> message to print to the console
-    character(len=*), intent(in)    :: msg
+    character(len=*), intent(in) :: msg
     !> colour of the message
-    character(len=*), intent(in)    :: colour
+    character(len=*), intent(in) :: colour
+    character(:), allocatable :: fmt
     !> new string with ANSI sequences added
-    character(len=*), intent(out)   :: msg_painted
+    character(:), allocatable :: msg_painted
 
     select case(colour)
       case("red")
@@ -63,7 +60,7 @@ contains
         msg_painted = msg
         return
     end select
-    msg_painted = fmt // msg // term
-  end subroutine paint_string
+    msg_painted = trim(adjustl(fmt // msg // term))
+  end function paint_string
   ! LCOV_EXCL_STOP
 end module mod_painting

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -6,6 +6,7 @@ module mod_eigenfunctions
   use mod_global_variables, only: dp, str_len_arr
   use mod_types, only: ef_type
   use mod_settings, only: settings_t
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -131,7 +132,6 @@ contains
   !> Returns the full set of eigenfunctions corresponding to the given eigenfunction
   !! name.
   function retrieve_eigenfunctions(name, state_vector) result(eigenfunctions)
-    use mod_logging, only: log_message
     use mod_get_indices, only: get_index
 
     !> name of the eigenfunction to retrieve
@@ -158,9 +158,7 @@ contains
       end if
     end if
     ! if still not found then something went wrong
-    call log_message( &
-      "could not retrieve eigenfunction with name " // name, level="error" &
-    )
+    call logger%error("could not retrieve eigenfunction with name " // name)
   end function retrieve_eigenfunctions
 
 

--- a/src/eigenfunctions/smod_derived_efs.f08
+++ b/src/eigenfunctions/smod_derived_efs.f08
@@ -70,13 +70,12 @@ contains
   subroutine check_if_pp_quantities_can_be_calculated()
     use mod_check_values, only: is_zero
     use mod_equilibrium, only: B_field
-    use mod_logging, only: log_message
 
     can_calculate_pp_quantities = .true.
     if (.not. is_zero(B_field % B01)) then
-      call log_message( &
+      call logger%warning( &
         "parallel/perpendicular derived quantities currently not supported &
-        &for non-zero B01 components", level="warning" &
+        &for non-zero B01 components" &
       )
       can_calculate_pp_quantities = .false.
     end if

--- a/src/eigenfunctions/smod_ef_operations.f08
+++ b/src/eigenfunctions/smod_ef_operations.f08
@@ -12,7 +12,6 @@ contains
     !! in this case the eigenfunction is divided by the scale factor.
   module procedure retransform_eigenfunction
     use mod_global_variables, only: ic
-    use mod_logging, only: log_message
 
     select case(name)
     case("rho", "v3", "T", "a2") ! var -> eps * var
@@ -24,7 +23,7 @@ contains
     case("a1") ! a1 -> i*a1
       eigenfunction = eigenfunction / ic
     case default
-      call log_message("wrong eigenfunction name during retransform", level="error")
+      call logger%error("wrong eigenfunction name during retransform")
     end select
   end procedure retransform_eigenfunction
 
@@ -98,7 +97,6 @@ contains
   !> Returns the finite element basis functions for the given eigenfunction and
   !! position in the grid.
   function get_spline(name, grid_idx, ef_grid_idx, diff_order) result(spline)
-    use mod_logging, only: log_message, str
     use mod_spline_functions
     use mod_grid, only: grid
 
@@ -124,9 +122,8 @@ contains
       case(2)
         spline_function => cubic_factors_deriv2
       case default
-        call log_message( &
-          "get_spline - invalid derivative order given (cubic): " // str(diff_order), &
-          level="error" &
+        call logger%error( &
+          "get_spline - invalid derivative order given (cubic): " // str(diff_order) &
         )
         return
       end select
@@ -138,17 +135,15 @@ contains
       case(1)
         spline_function => quadratic_factors_deriv
       case default
-        call log_message( &
-          "get_spline - invalid order given (quadratic): " // str(diff_order), &
-          level="error" &
+        call logger%error( &
+          "get_spline - invalid order given (quadratic): " // str(diff_order) &
         )
         return
       end select
 
     case default
-      call log_message( &
-        "get_spline - invalid eigenfunction name given: " // name, &
-        level="error" &
+      call logger%error( &
+        "get_spline - invalid eigenfunction name given: " // name &
       )
     end select
 

--- a/src/equilibria/smod_equil_coronal_flux_tube.f08
+++ b/src/equilibria/smod_equil_coronal_flux_tube.f08
@@ -99,16 +99,14 @@ contains
     )
 
     if (r0 > x_end) then
-      call log_message("equilibrium: inner cylinder radius r0 > x_end", level="error")
+      call logger%error("equilibrium: inner cylinder radius r0 > x_end")
     else if (r0 < x_start) then
-      call log_message("equilibrium: inner cylinder radius r0 < x_start", level="error")
+      call logger%error("equilibrium: inner cylinder radius r0 < x_start")
     end if
 
     ! check pressure balance
     if (abs(cte_p0 + 0.5d0 * B_0**2 - p_e - 0.5d0 * B_e**2) > dp_LIMIT) then
-      call log_message( &
-        "equilibrium: total pressure balance not satisfied", level="error" &
-      )
+      call logger%error("equilibrium: total pressure balance not satisfied")
     end if
 
     do i = 1, settings%grid%get_gauss_gridpts()

--- a/src/equilibria/smod_equil_photospheric_flux_tube.f08
+++ b/src/equilibria/smod_equil_photospheric_flux_tube.f08
@@ -98,16 +98,14 @@ contains
     B_e = sqrt(2.0d0 * gamma * cte_p0 * (2.0d0 * gamma + 1.0d0) / (gamma + 18.0d0))
 
     if (r0 > x_end) then
-      call log_message("equilibrium: inner cylinder radius r0 > x_end", level="error")
+      call logger%error("equilibrium: inner cylinder radius r0 > x_end")
     else if (r0 < x_start) then
-      call log_message("equilibrium: inner cylinder radius r0 < x_start", level="error")
+      call logger%error("equilibrium: inner cylinder radius r0 < x_start")
     end if
 
     ! check pressure balance
     if (abs(cte_p0 + 0.5d0 * B_0**2 - p_e - 0.5d0 * B_e**2) > dp_LIMIT) then
-      call log_message( &
-        "equilibrium: total pressure balance not satisfied", level="error" &
-      )
+      call logger%error("equilibrium: total pressure balance not satisfied")
     end if
 
     do i = 1, settings%grid%get_gauss_gridpts()

--- a/src/equilibria/smod_equil_taylor_couette.f08
+++ b/src/equilibria/smod_equil_taylor_couette.f08
@@ -83,7 +83,7 @@ contains
 
     Ta = (cte_rho0 * (v_field % v02(int(gauss_gridpts/2))) * h / viscosity_value)**2 &
           * 2.0d0 * h / (x_start + x_end)
-    call log_message('Taylor number is ' // str(int(Ta)), level='info')
+    call logger%info('Taylor number is ' // str(int(Ta)))
 
   end procedure taylor_couette_eq
 

--- a/src/equilibria/smod_equil_tc_pinch.f08
+++ b/src/equilibria/smod_equil_tc_pinch.f08
@@ -110,14 +110,14 @@ contains
 
     Ta = (cte_rho0 * (v_field % v02(int(gauss_gridpts/2))) * h / viscosity_value)**2 &
           * 2.0d0 * h / (x_start + x_end)
-    call log_message('Taylor number:    ' // str(Ta, fmt='(e8.2)'), level='info')
+    call logger%info("Taylor number:  " // str(Ta, fmt=exp_fmt))
     Pm = viscosity_value / (cte_rho0 * fixed_eta_value)
-    call log_message('Prandtl number:   ' // str(Pm, fmt='(e8.2)'), level='info')
+    call logger%info("Prandtl number: " // str(Pm, fmt=exp_fmt))
     Ha = cte_B02 * sqrt(x_start * (x_end - x_start)) &
           / sqrt(viscosity_value * fixed_eta_value)
-    call log_message('Hartmann number:  ' // str(Ha, fmt='(e8.2)'), level='info')
+    call logger%info("Hartmann number " // str(Ha, fmt=exp_fmt))
     Re = alpha * cte_rho0 * x_start * (x_end - x_start) / viscosity_value
-    call log_message('Reynolds number:  ' // str(Re, fmt='(e8.2)'), level='info')
+    call logger%info("Reynolds number " // str(Re, fmt=exp_fmt))
 
   end procedure tc_pinch_eq
 

--- a/src/matrices/datastructure/mod_banded_matrix.f08
+++ b/src/matrices/datastructure/mod_banded_matrix.f08
@@ -2,7 +2,7 @@
 !! as explained in the LAPACK guide http://www.netlib.org/lapack/lug/node124.html.
 module mod_banded_matrix
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -49,10 +49,9 @@ contains
     type(banded_matrix_t) :: matrix
 
     if (.not. dimensions_are_valid(rows, cols)) then
-      call log_message( &
+      call logger%error( &
         "banded matrix creation failed, expected a square matrix but got " &
-        // str(rows) // " x " // str(cols), &
-        level="error" &
+        // str(rows) // " x " // str(cols) &
       )
       return
     end if

--- a/src/matrices/datastructure/mod_banded_matrix_hermitian.f08
+++ b/src/matrices/datastructure/mod_banded_matrix_hermitian.f08
@@ -3,7 +3,7 @@
 !! http://www.netlib.org/lapack/lug/node124.html.
 module mod_banded_matrix_hermitian
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -45,9 +45,8 @@ contains
     type(hermitian_banded_matrix_t) :: matrix
 
     if (.not. uplo_is_valid(uplo)) then
-      call log_message( &
-        "invalid uplo argument, expected 'U' or 'L', got '" // uplo // "'", &
-        level="error" &
+      call logger%error( &
+        "invalid uplo argument, expected 'U' or 'L', got '" // uplo // "'" &
       )
       return
     end if

--- a/src/matrices/datastructure/mod_matrix_node.f08
+++ b/src/matrices/datastructure/mod_matrix_node.f08
@@ -3,7 +3,6 @@
 !! representation.
 module mod_matrix_node
   use mod_global_variables, only: dp, NaN
-  use mod_logging, only: log_message
   implicit none
 
   private

--- a/src/matrices/datastructure/mod_matrix_row.f08
+++ b/src/matrices/datastructure/mod_matrix_row.f08
@@ -2,7 +2,6 @@
 !> Module that contains the implementation of a single row of nodes in the
 !! linked-list matrix representation.
 module mod_matrix_row
-  use mod_logging, only: log_message, str
   use mod_matrix_node, only: node_t, new_node
   implicit none
 

--- a/src/matrices/datastructure/mod_matrix_structure.f08
+++ b/src/matrices/datastructure/mod_matrix_structure.f08
@@ -2,7 +2,7 @@
 !> Module that contains the datastructure for a linked-list matrix representation.
 module mod_matrix_structure
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_matrix_node, only: node_t
   use mod_matrix_row, only: row_t, new_row
   implicit none
@@ -108,7 +108,7 @@ contains
       type is (integer)
         is_valid = (element /= 0)
       class default
-        call log_message("adding unexpected element type", level="error")
+        call logger%error("adding unexpected element type")
     end select
   end function is_valid_element
 
@@ -124,9 +124,8 @@ contains
 
     is_valid = .true.
     if (index <= 0 .or. index > matrix%matrix_dim) then
-      call log_message( &
-        "row/column index " // str(index) // " is outside of matrix dimension", &
-        level="error" &
+      call logger%error( &
+        "row/column index " // str(index) // " is outside of matrix dimension" &
       )
       is_valid = .false.
     end if

--- a/src/matrices/datastructure/mod_transform_matrix.f08
+++ b/src/matrices/datastructure/mod_transform_matrix.f08
@@ -3,7 +3,7 @@
 !! matrix representations, banded matrix representations, and full array matrices.
 module mod_transform_matrix
   use mod_global_variables, only: dp, NaN
-  use mod_logging, only: log_message
+  use mod_logging, only: logger
   use mod_matrix_structure, only: matrix_t, new_matrix
   use mod_banded_matrix, only: banded_matrix_t, new_banded_matrix
   use mod_banded_matrix_hermitian, only: hermitian_banded_matrix_t, &
@@ -210,9 +210,7 @@ contains
     nrows = size(array, dim=1)
     ncols = size(array, dim=2)
     if (nrows /= ncols) then
-      call log_message( &
-        "array_to_complex_hermitian_banded: array is not square", level="error" &
-      )
+      call logger%error("array_to_complex_hermitian_banded: array is not square")
       return
     end if
     banded = new_hermitian_banded_matrix(rows=nrows, diags=diags, uplo=uplo)

--- a/src/matrices/mod_matrix_manager.f08
+++ b/src/matrices/mod_matrix_manager.f08
@@ -4,7 +4,7 @@ module mod_matrix_manager
   use mod_make_subblock, only: subblock
   use mod_equilibrium, only: rho_field, T_field, B_field
   use mod_equilibrium_params, only: k2, k3
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_matrix_shortcuts, only: get_G_operator, get_F_operator, get_wv_operator
   use mod_settings, only: settings_t
   implicit none

--- a/src/matrices/mod_matrix_shortcuts.f08
+++ b/src/matrices/mod_matrix_shortcuts.f08
@@ -3,7 +3,7 @@ module mod_matrix_shortcuts
   use mod_equilibrium, only: B_field
   use mod_equilibrium_params, only: k2, k3
   use mod_grid, only: eps_grid, d_eps_grid_dr
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -41,9 +41,7 @@ contains
       )
     else
       Foperator = NaN
-      call log_message( &
-        "requesting invalid F-operator sign: " // trim(which), level="error" &
-      )
+      call logger%error("requesting invalid F-operator sign: " // trim(which))
     end if
   end function get_F_operator
 
@@ -81,9 +79,7 @@ contains
       )
     else
       dFoperator = NaN
-      call log_message( &
-        "requesting invalid dF-operator sign: " // trim(which), level="error" &
-      )
+      call logger%error("requesting invalid dF-operator sign: " // trim(which))
     end if
   end function get_diffF_operator
 
@@ -113,9 +109,7 @@ contains
       )
     else
       Goperator = NaN
-      call log_message( &
-        "requesting invalid G-operator sign: " // trim(which), level="error" &
-      )
+      call logger%error("requesting invalid G-operator sign: " // trim(which))
     end if
   end function get_G_operator
 
@@ -169,7 +163,7 @@ contains
       Kp_operator = Kp_plusplus
     else
       Kp_operator = NaN
-      call log_message("requesting invalid Kp-operator: " // trim(which), level="error")
+      call logger%error("requesting invalid Kp-operator: " // trim(which))
     end if
   end function get_Kp_operator
 end module mod_matrix_shortcuts

--- a/src/matrices/smod_resistive_matrix.f08
+++ b/src/matrices/smod_resistive_matrix.f08
@@ -227,9 +227,7 @@ contains
       Roperator = (deps * eta / eps - deta)
     else
       Roperator = NaN
-      call log_message( &
-        "requesting invalid R-operator sign: " // trim(which), level="error" &
-      )
+      call logger%error("requesting invalid R-operator sign: " // trim(which))
     end if
   end function get_R_operator
 

--- a/src/mod_check_values.f08
+++ b/src/mod_check_values.f08
@@ -5,7 +5,6 @@
 module mod_check_values
   use, intrinsic :: ieee_arithmetic, only: ieee_is_nan, ieee_is_finite
   use mod_global_variables, only: dp, dp_LIMIT
-  use mod_logging, only: log_message, str
   implicit none
 
   private

--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -14,7 +14,7 @@ module mod_equilibrium
   use mod_physical_constants, only: dpi
   use mod_grid, only: initialise_grid, grid_gauss
   use mod_equilibrium_params, only: k2, k3
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str, exp_fmt
   use mod_settings, only: settings_t
   implicit none
 
@@ -193,9 +193,7 @@ contains
 
     ! Check x_start if coaxial is true
     if (settings%grid%coaxial .and. settings%grid%get_grid_start() <= dp_LIMIT) then
-      call log_message( &
-        "x_start must be > 0 to introduce an inner wall boundary", level="error" &
-      )
+      call logger%error("x_start must be > 0 to introduce an inner wall boundary")
       return
     end if
 
@@ -299,10 +297,9 @@ contains
     case("user_defined")
       set_equilibrium_values => user_defined_eq
     case default
-      call log_message( &
+      call logger%error( &
         "equilibrium not recognised: " &
-        // trim(settings%equilibrium%get_equilibrium_type()), &
-        level="error" &
+        // trim(settings%equilibrium%get_equilibrium_type()) &
       )
     end select
   end subroutine set_equilibrium_pointer

--- a/src/mod_global_variables.f08
+++ b/src/mod_global_variables.f08
@@ -41,9 +41,6 @@ module mod_global_variables
     0.347854845137454, 0.652145154862546, 0.652145154862546, 0.347854845137454 &
   ]
 
-  !> sets the logging level, defaults to 2 (errors, warnings and info)
-  integer                   :: logging_level
-
 contains
 
 
@@ -57,8 +54,6 @@ contains
     use, intrinsic :: ieee_arithmetic, only: ieee_value, ieee_quiet_nan
 
     NaN = ieee_value(NaN, ieee_quiet_nan)
-
-    logging_level = 2
   end subroutine initialise_globals
 
 end module mod_global_variables

--- a/src/mod_grid.f08
+++ b/src/mod_grid.f08
@@ -10,7 +10,7 @@
 !! $$ x_i(j) = 0.5 * dx * w_i(j) + 0.5(a + b) $$
 module mod_grid
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_settings, only: settings_t
   implicit none
 
@@ -61,7 +61,7 @@ contains
 
     geometry = settings%grid%get_geometry()
     if (geometry == "") then
-      call log_message("geometry must be set in submodule/parfile", level="error")
+      call logger%error("geometry must be set in submodule/parfile")
       return
     end if
 
@@ -79,24 +79,22 @@ contains
     grid_gauss = 0.0d0
 
     if (present(custom_grid)) then
-      call log_message("using a custom base grid", level="info")
+      call logger%info("using a custom base grid")
       ! check if size matches gridpoints
       if (size(custom_grid) /= gridpts) then
-        call log_message( &
+        call logger%error( &
           "custom grid: sizes do not match! Expected "// str(gridpts) // &
-          " points but got " // str(size(custom_grid)), &
-          level="error" &
+          " points but got " // str(size(custom_grid)) &
         )
         return
       end if
       ! check if grid is monotonous
       do i = 1, size(custom_grid) - 1
         if (.not. (custom_grid(i + 1) > custom_grid(i))) then
-          call log_message( &
+          call logger%error( &
             "custom grid: supplied array is not monotone! Got x=" // &
             str(custom_grid(i)) // " at index " // str(i) // " and x=" // &
-            str(custom_grid(i + 1)) // " at index " // str(i + 1), &
-            level="error" &
+            str(custom_grid(i + 1)) // " at index " // str(i + 1) &
           )
           return
         end if
@@ -107,10 +105,9 @@ contains
         if (.not. settings%grid%force_r0) then
           x_start = 2.5d-2
         else
-          call log_message( &
+          call logger%warning( &
             "forcing on-axis r in cylindrical geometry. This may lead to spurious &
-            &real/imaginary eigenvalues.", &
-            level="warning" &
+            &real/imaginary eigenvalues." &
           )
           x_start = 0.0d0
         end if
@@ -169,9 +166,7 @@ contains
       eps_grid = grid_gauss
       d_eps_grid_dr = 1.0d0
     else
-      call log_message( &
-        "geometry not defined correctly: " // trim(geometry), level="error" &
-      )
+      call logger%error("geometry not defined correctly: " // trim(geometry))
     end if
   end subroutine set_scale_factor
 

--- a/src/mod_integration.f08
+++ b/src/mod_integration.f08
@@ -7,6 +7,7 @@
 !! These are solved using a fifth-order Runge-Kutta method.
 module mod_integration
   use mod_global_variables, only: dp, dp_LIMIT
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -42,7 +43,6 @@ contains
     new_xvalues &
   )
     use mod_interpolation, only: interpolate_table
-    use mod_logging, only: log_message, str
 
     !> array of x-values
     real(dp), intent(in)  :: xvalues(:)
@@ -124,15 +124,11 @@ contains
     if (present(adaptive)) then
       use_adaptive_stepping = adaptive
       if (use_adaptive_stepping) then
-        call log_message( &
-          "integrating using adaptive stepping, max dh change = " &
-            // str(max_dh_fact, fmt="f5.1"), &
-          level="info" &
+        call logger%info( &
+          "integrating using adaptive stepping, max dh change = "// str(max_dh_fact) &
         )
       else
-        call log_message( &
-          "integrating using regular stepping, dh = " // str(dh), level="info" &
-        )
+        call logger%info("integrating using regular stepping, dh = " // str(dh))
       end if
     end if
 
@@ -207,11 +203,9 @@ contains
       ytemp(i) = ysolrk5
       ! LCOV_EXCL_START
       if (mod(i, 10000) == 0) then
-        call log_message( &
+        call logger%info( &
           "steps: " // str(i) // " | xi: " // str(xi) // " | dh: " &
-          // str(dh, fmt="e20.5"), &
-          level="info", &
-          use_prefix=.false. &
+          // str(dh, fmt="e20.5") &
         )
       end if
       ! LCOV_EXCL_STOP
@@ -319,8 +313,6 @@ contains
 
   !> Checks if an array needs resampling.
   function needs_resampling(base, target, array_name) result(resample)
-    use mod_logging, only: log_message, str
-
     !> size of base array
     integer, intent(in) :: base
     !> size of target array
@@ -332,9 +324,8 @@ contains
 
     ! LCOV_EXCL_START
     if (target < base) then
-      call log_message( &
-        "resampling: target #points is less than size of input arrays!", &
-        level="warning" &
+      call logger%warning( &
+        "resampling: target #points is less than size of input arrays!" &
       )
     end if
     ! LCOV_EXCL_STOP
@@ -342,10 +333,9 @@ contains
     if (base == target) then
       resample = .false.
     else
-      call log_message( &
+      call logger%info( &
         "ode integrator: resampling " // trim(adjustl(array_name)) // " (" &
-        // str(base) // " -> " // str(target) // " points)", &
-        level="info" &
+        // str(base) // " -> " // str(target) // " points)" &
       )
       resample = .true.
     end if

--- a/src/mod_interpolation.f08
+++ b/src/mod_interpolation.f08
@@ -6,7 +6,7 @@
 !! [MPI-AMRVAC](amrvac.org) code.
 module mod_interpolation
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message
+  use mod_logging, only: logger
   implicit none
 
   private
@@ -45,9 +45,7 @@ contains
     ! check if x_table is a monotonically increasing array
     do i = 1, n_table - 1
       if (x_table(i + 1) < x_table(i)) then
-        call log_message( &
-          "interpolation: x-values are not monotonically increasing!", level="error" &
-        )
+        call logger%error("interpolation: x-values are not monotonically increasing!")
         return
       end if
     end do
@@ -133,10 +131,7 @@ contains
 
     ! x_values and y_values should be the same length
     if (size(x) /= size(y)) then
-      call log_message( &
-        "numerical derivative: x and y should have the same size!", &
-        level="error" &
-      )
+      call logger%error("numerical derivative: x and y should have the same size!")
       return
     end if
     nbprints = 0
@@ -151,24 +146,17 @@ contains
     do i = 2, nvals-1
       dxi = x(i) - x(i-1)
       if (.not. is_equal(dx, dxi, tol=tol)) then
-        call log_message( &
-          "numerical derivative: x is not equally spaced, derivative may be wrong!", &
-          level="warning" &
+        call logger%warning( &
+          "numerical derivative: x is not equally spaced, derivative may be wrong!" &
         )
-        call log_message( &
+        call logger%warning( &
           "at index " // str(i) // " expected dx=" // str(dx, fmt="e20.10") // &
-          " but got dx=" // str(dxi, fmt="e20.10"), &
-          level="warning", &
-          use_prefix=.false. &
+          " but got dx=" // str(dxi, fmt="e20.10") &
         )
-        call log_message( &
-          "---> diff = " // str(abs(dx - dxi), fmt="e20.6"), &
-          level="warning", &
-          use_prefix=.false. &
-        )
+        call logger%warning("---> diff = " // str(abs(dx - dxi), fmt="e20.6"))
         nbprints = nbprints + 1
         if (nbprints == 10) then
-          call log_message("...", level="warning", use_prefix=.false.)
+          call logger%warning("...")
           exit
         end if
       end if
@@ -254,11 +242,11 @@ contains
 
     ! check if we are outside of the table
     if (x < x_values(1)) then
-      call log_message("lookup_value: x outside x_values (too small)", level="error")
+      call logger%error("lookup_value: x outside x_values (too small)")
       y_found = NaN
       return
     else if (x > x_values(nvals)) then
-      call log_message("lookup_value: x outside x_values (too large)", level="error")
+      call logger%error("lookup_value: x outside x_values (too large)")
       y_found = NaN
       return
     end if

--- a/src/physics/mod_resistivity.f08
+++ b/src/physics/mod_resistivity.f08
@@ -105,7 +105,7 @@ contains
   !! - a dropoff profile is requested but the resistivity is not constant. @endwarning
   subroutine set_eta_dropoff(settings, eta_field)
     use mod_types, only: resistivity_type
-    use mod_logging, only: log_message, str
+    use mod_logging, only: logger, str
     use mod_grid, only: grid_gauss
     use mod_physical_constants, only: dpi
 
@@ -118,9 +118,7 @@ contains
     integer :: i, gauss_gridpts
 
     if (.not. settings%physics%resistivity%has_fixed_resistivity()) then
-      call log_message( &
-        'eta dropoff only possible with a fixed resistivity value', level='error' &
-      )
+      call logger%error("eta dropoff only possible with a fixed resistivity value")
       return
     end if
 
@@ -134,9 +132,9 @@ contains
     shift = etaval * tanh(-dpi) / (tanh(-dpi) - tanh(dpi))
     stretch = etaval / (tanh(dpi) - tanh(-dpi))
 
-    call log_message('setting eta-dropoff profile', level='info')
-    call log_message('dropoff width = ' // str(width), level='info')
-    call log_message('distance from edge = ' // str(edge_dist), level='info')
+    call logger%info("setting eta-dropoff profile")
+    call logger%info("dropoff width = " // str(width))
+    call logger%info("distance from edge = " // str(edge_dist))
 
     do i = 1, gauss_gridpts
       x = grid_gauss(i)

--- a/src/physics/mod_thermal_conduction.f08
+++ b/src/physics/mod_thermal_conduction.f08
@@ -4,7 +4,7 @@
 module mod_thermal_conduction
   use mod_global_variables, only: dp
   use mod_physical_constants, only: dpi, coulomb_log
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_settings, only: settings_t
   implicit none
 
@@ -141,7 +141,7 @@ contains
 
     if (settings%physics%conduction%has_fixed_tc_para()) return
 
-    call log_message("setting kappa_para derivatives", level="debug")
+    call logger%debug("setting kappa_para derivatives")
     unit_temperature = settings%units%get_unit_temperature()
     unit_dtc_dT = settings%units%get_unit_conduction() / unit_temperature
     T0_dimfull = T0_eq * unit_temperature
@@ -179,7 +179,7 @@ contains
 
     if (settings%physics%conduction%has_fixed_tc_perp()) return
 
-    call log_message("setting kappa_perp rho, T, B derivatives", level="debug")
+    call logger%debug("setting kappa_perp rho, T, B derivatives")
     unit_conduction = settings%units%get_unit_conduction()
     ! re-dimensionalise variables, in normalised units nH = rho
     nH_dimfull = rho0_eq * settings%units%get_unit_numberdensity()
@@ -228,7 +228,7 @@ contains
 
     if (settings%physics%conduction%has_fixed_tc_perp()) return
 
-    call log_message("setting kappa_perp radial derivative", level="debug")
+    call logger%debug("setting kappa_perp radial derivative")
     ! magnetic field derivative
     dB0 = ( &
       B_field % B02 * B_field % d_B02_dr + B_field % B03 * B_field % d_B03_dr &
@@ -263,7 +263,7 @@ contains
     real(dp)  :: d_kappa_para_dr(size(T_field % T0))
     real(dp)  :: dB0(size(B_field % B0))
 
-    call log_message("setting conduction prefactor", level="debug")
+    call logger%debug("setting conduction prefactor")
     ! calculate and set conduction prefactor
     kappa_field % prefactor = ( &
       (kappa_field % kappa_para - kappa_field % kappa_perp) / (B_field % B0**2) &
@@ -276,7 +276,7 @@ contains
       B_field % B02 * B_field % d_B02_dr + B_field % B03 * B_field % d_B03_dr &
     ) / B_field % B0
 
-    call log_message("setting conduction prefactor radial derivative", level="debug")
+    call logger%debug("setting conduction prefactor radial derivative")
     kappa_field % d_prefactor_dr = ( &
       (d_kappa_para_dr - kappa_field % d_kappa_perp_dr) * B_field % B0 &
       - 2.0d0 * (kappa_field % kappa_para - kappa_field % kappa_perp) * dB0 &

--- a/src/settings/mod_equilibrium_settings.f08
+++ b/src/settings/mod_equilibrium_settings.f08
@@ -38,7 +38,7 @@ contains
   pure function get_equilibrium_type(this) result(equilibrium_type)
     class(equilibrium_settings_t), intent(in) :: this
     character(len=:), allocatable :: equilibrium_type
-    equilibrium_type = this%equilibrium_type
+    equilibrium_type = trim(adjustl(this%equilibrium_type))
   end function get_equilibrium_type
 
 
@@ -52,7 +52,7 @@ contains
   pure function get_boundary_type(this) result(boundary_type)
     class(equilibrium_settings_t), intent(in) :: this
     character(len=:), allocatable :: boundary_type
-    boundary_type = this%boundary_type
+    boundary_type = trim(adjustl(this%boundary_type))
   end function get_boundary_type
 
   pure subroutine delete(this)

--- a/src/settings/mod_io_settings.f08
+++ b/src/settings/mod_io_settings.f08
@@ -63,7 +63,7 @@ contains
   pure function get_basename_datfile(this) result(basename_datfile)
     class(io_t), intent(in) :: this
     character(len=:), allocatable :: basename_datfile
-    basename_datfile = this%basename_datfile
+    basename_datfile = trim(adjustl(this%basename_datfile))
   end function get_basename_datfile
 
 
@@ -77,7 +77,7 @@ contains
   pure function get_output_folder(this) result(output_folder)
     class(io_t), intent(in) :: this
     character(len=:), allocatable :: output_folder
-    output_folder = this%output_folder
+    output_folder = trim(adjustl(this%output_folder))
   end function get_output_folder
 
 

--- a/src/settings/mod_settings.f08
+++ b/src/settings/mod_settings.f08
@@ -94,7 +94,7 @@ contains
     class(settings_t), intent(in) :: this
     character(len=:), allocatable :: physics_type
 
-    physics_type = this%physics_type
+    physics_type = trim(adjustl(this%physics_type))
   end function get_physics_type
 
 

--- a/src/settings/mod_solver_settings.f08
+++ b/src/settings/mod_solver_settings.f08
@@ -56,7 +56,7 @@ contains
     class(solvers_t), intent(in) :: this
     character(:), allocatable :: solver
 
-    solver = this%solver
+    solver = trim(adjustl(this%solver))
   end function get_solver
 
 
@@ -72,7 +72,7 @@ contains
     class(solvers_t), intent(in) :: this
     character(:), allocatable :: arpack_mode
 
-    arpack_mode = this%arpack_mode
+    arpack_mode = trim(adjustl(this%arpack_mode))
   end function get_arpack_mode
 
 

--- a/src/settings/physics/mod_cooling_settings.f08
+++ b/src/settings/physics/mod_cooling_settings.f08
@@ -73,7 +73,7 @@ contains
   pure function get_cooling_curve(this) result(cooling_curve)
     class(cooling_settings_t), intent(in) :: this
     character(:), allocatable :: cooling_curve
-    cooling_curve = this%cooling_curve
+    cooling_curve = trim(adjustl(this%cooling_curve))
   end function get_cooling_curve
 
 end module mod_cooling_settings

--- a/src/solvers/arnoldi/smod_arpack_general.f08
+++ b/src/solvers/arnoldi/smod_arpack_general.f08
@@ -38,16 +38,16 @@ contains
     ! we need? This is problem-dependent so in some cases there might be quite some
     ! room here for optimisations
     diags = settings%dims%get_dim_quadblock() - 1
-    call log_message("converting A-matrix into banded structure", level="debug")
+    call logger%debug("converting A-matrix into banded structure")
     call matrix_to_banded( &
       matrix=matrix_A, subdiags=diags, superdiags=diags, banded=amat_banded &
     )
-    call log_message("converting B-matrix into banded structure", level="debug")
+    call logger%debug("converting B-matrix into banded structure")
     call matrix_to_banded( &
       matrix=matrix_B, subdiags=diags, superdiags=diags, banded=bmat_banded &
     )
 
-    call log_message("doing Arnoldi iteration", level="debug")
+    call logger%debug("doing Arnoldi iteration")
     converged = .false.
     ! we keep iterating for as long as the eigenvalues are not converged.
     ! If convergence is achieved or the maximum number of iterations is reached,

--- a/src/solvers/arnoldi/smod_arpack_main.f08
+++ b/src/solvers/arnoldi/smod_arpack_main.f08
@@ -56,7 +56,7 @@ contains
 
     select case(settings%solvers%get_arpack_mode())
     case("general")
-      call log_message("Arnoldi iteration, general mode", level="debug")
+      call logger%debug("Arnoldi iteration, general mode")
       arpack_cfg = new_arpack_config( &
         evpdim=matrix_A%matrix_dim, &
         mode=1, &
@@ -65,7 +65,7 @@ contains
       )
       call solve_arpack_general(arpack_cfg, matrix_A, matrix_B, settings, omega, vr)
     case("shift-invert")
-      call log_message("Arnoldi iteration, shift-invert mode", level="debug")
+      call logger%debug("Arnoldi iteration, shift-invert mode")
       arpack_cfg = new_arpack_config( &
         evpdim=matrix_A%matrix_dim, &
         mode=2, &
@@ -76,9 +76,8 @@ contains
         arpack_cfg, matrix_A, matrix_B, settings, omega, vr &
       )
     case default
-      call log_message( &
-        "unknown mode for ARPACK: " // settings%solvers%get_arpack_mode(), &
-        level="error" &
+      call logger%error( &
+        "unknown mode for ARPACK: " // settings%solvers%get_arpack_mode() &
       )
       return
     end select
@@ -86,12 +85,8 @@ contains
     call arpack_cfg%destroy()
 
 #else
-  call log_message( &
-    "ARPACK was not found and/or CMake failed to link", level="warning" &
-  )
-  call log_message( &
-    "unable to use 'arnoldi', try another solver!", level="error" &
-  )
+  call logger%warning("ARPACK was not found and/or CMake failed to link")
+  call logger%error("unable to use 'arnoldi', try another solver!")
 #endif
   end procedure arnoldi
 

--- a/src/solvers/arnoldi/smod_arpack_shift_invert.f08
+++ b/src/solvers/arnoldi/smod_arpack_shift_invert.f08
@@ -39,16 +39,14 @@ contains
     complex(dp) :: sigma
 
     sigma = settings%solvers%sigma
-    call log_message("creating banded A - sigma*B", level="debug")
+    call logger%debug("creating banded A - sigma*B")
     diags = settings%dims%get_dim_quadblock() - 1
     call matrix_to_banded(matrix_A, diags, diags, amat_min_sigmab_banded)
     call matrix_to_banded(matrix_B, diags, diags, bmat_banded)
 
     ! check compatibility
     if (.not. amat_min_sigmab_banded%is_compatible_with(bmat_banded)) then
-      call log_message( &
-        "Arnoldi shift-invert: banded matrices are not compatible!", level="error" &
-      )
+      call logger%error("Arnoldi shift-invert: banded matrices are not compatible!")
       call amat_min_sigmab_banded%destroy()
       call bmat_banded%destroy()
       return
@@ -60,7 +58,7 @@ contains
       bandmatrix=amat_min_sigmab_banded, LU=amat_min_sigmab_LU, ipiv=ipiv_LU &
     )
 
-    call log_message("doing Arnoldi shift-invert", level="debug")
+    call logger%debug("doing Arnoldi shift-invert")
     converged = .false.
     do while(.not. converged)
       call znaupd( &
@@ -145,9 +143,8 @@ contains
       arpack_cfg%info &
     )
 
-    call log_message( &
-      "performing eigenvalue backtransformation to original problem (nu -> omega)", &
-      level="debug" &
+    call logger%debug( &
+      "performing eigenvalue backtransformation to original problem (nu -> omega)" &
     )
     !> @note In applying shift-invert we made the transformation \(C = inv[B]*A\) and
     !! solved the standard eigenvalue problem \(CX = \nu X\) instead since B isn't

--- a/src/solvers/mod_linear_systems.f08
+++ b/src/solvers/mod_linear_systems.f08
@@ -3,7 +3,7 @@
 module mod_linear_systems
   use mod_global_variables, only: dp
   use mod_banded_matrix, only: banded_matrix_t
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -132,9 +132,8 @@ contains
     integer, intent(in) :: info
     character(len=*), intent(in) :: routine_name
 
-    call log_message( &
-      "LAPACK routine " // routine_name // " failed! info = " // str(info), &
-      level="warning" &
+    call logger%warning( &
+      "LAPACK routine " // routine_name // " failed! info = " // str(info) &
     )
   end subroutine throw_info_nonzero_warning
   ! LCOV_EXCL_STOP

--- a/src/solvers/mod_solvers.f08
+++ b/src/solvers/mod_solvers.f08
@@ -4,7 +4,7 @@
 !! correct solver based on parfile settings.
 module mod_solvers
   use mod_global_variables, only: dp, NaN
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   use mod_check_values, only: set_small_values_to_zero
   use mod_matrix_structure, only: matrix_t
   use mod_transform_matrix, only: matrix_to_array
@@ -117,9 +117,7 @@ contains
       omega = NaN * (1, 1)
       if (settings%io%should_compute_eigenvectors()) vr = NaN * (1, 1)
     case default
-      call log_message( &
-        "unknown solver passed: " // settings%solvers%get_solver(), level="error" &
-      )
+      call logger%error("unknown solver passed: " // settings%solvers%get_solver())
       return
     end select
   end subroutine solve_evp

--- a/src/solvers/smod_inverse_iteration.f08
+++ b/src/solvers/smod_inverse_iteration.f08
@@ -53,24 +53,22 @@ contains
 
     ! check input sanity
     if (.not. (matrix_A%matrix_dim == matrix_B%matrix_dim)) then
-      call log_message("A or B not square, or not compatible", level="error")
+      call logger%error("A or B not square, or not compatible")
+      return
     end if
 
     ! if maxiter is not set in the parfile it's still 0, default to 100
     if (maxiter == 0) then
       maxiter = 100
     else if (maxiter < 0) then
-      call log_message( &
-        "maxiter has to be positive, but is equal to " // str(maxiter), level="error" &
+      call logger%error( &
+        "maxiter has to be positive, but is equal to " // str(maxiter) &
       )
       return
     end if
 
     if (is_equal(sigma, (0.0d0, 0.0d0))) then
-      call log_message( &
-        "inverse-iteration: sigma can not be equal to zero", &
-        level="error" &
-      )
+      call logger%error("inverse-iteration: sigma can not be equal to zero")
       return
     end if ! LCOV_EXCL_STOP
 
@@ -103,9 +101,8 @@ contains
     allocate(LU_ipiv(N))
     call zgbtrf(N, N, kd, kd, LU%AB, LU%kl+LU%ku+1, LU_ipiv, info)
     if (info /= 0) then ! LCOV_EXCL_START
-      call log_message( &
-        "[A - sigma * B](" // str(info) // "," // str(info) // ") is zero", &
-        level="warning" &
+      call logger%warning( &
+        "[A - sigma * B](" // str(info) // "," // str(info) // ") is zero" &
       )
     end if ! LCOV_EXCL_STOP
 
@@ -176,23 +173,11 @@ contains
     ! if we did not converge, raise a warning
     if (.not.converged) then
       if (i == maxiter+1) then
-        call log_message( &
-          "Inverse iteration failed to converge! (maxiter reached)", level="warning" &
-        )
-        call log_message( &
-          "number of iterations: " // str(maxiter), &
-          level="warning", &
-          use_prefix=.false. &
-        )
+        call logger%warning("Inverse iteration failed to converge! (maxiter reached)")
+        call logger%warning("number of iterations: " // str(maxiter))
       else
-        call log_message( &
-          "Inverse iteration failed to converge! (divergence)", level="warning" &
-        )
-        call log_message( &
-          "number of iterations: " // str(i), &
-          level="warning", &
-          use_prefix=.false. &
-        )
+        call logger%warning("Inverse iteration failed to converge! (divergence)")
+        call logger%warning("number of iterations: " // str(i))
       end if
     end if
 

--- a/src/solvers/smod_qr_invert.f08
+++ b/src/solvers/smod_qr_invert.f08
@@ -44,12 +44,11 @@ contains
     integer :: irow, icol
 
     call matrix_B%get_nb_diagonals(ku=ku, kl=kl)
-    call log_message( &
-      "B has " // str(ku) // " superdiagonals and " // str(kl) // " subdiagonals", &
-      level="debug" &
+    call logger%debug( &
+      "B has " // str(ku) // " superdiagonals and " // str(kl) // " subdiagonals" &
     )
     N = matrix_B%matrix_dim
-    call log_message("converting B to banded form", level="debug")
+    call logger%debug("converting B to banded form")
     ! for zgbsv later on we need double the amount of subdiagonals
     B_band = new_banded_matrix(rows=N, cols=N, subdiags=2*kl, superdiags=ku)
     ! fill banded matrix, see documentation: "The j-th column of B is stored in the
@@ -62,12 +61,12 @@ contains
     end do
 
     allocate(array_B_invA(matrix_A%matrix_dim, matrix_A%matrix_dim))
-    call log_message("converting A to dense form", level="debug")
+    call logger%debug("converting A to dense form")
     call matrix_to_array(matrix=matrix_A, array=array_B_invA)
 
     ! zgbsv calculates X from BX = A, where B is a banded matrix.
     ! solving this system yields X = B^{-1}A without explicitly inverting
-    call log_message("calling LAPACK's zgbsv", level="debug")
+    call logger%debug("calling LAPACK's zgbsv")
     call zgbsv( &
       B_band%m, &
       kl, &
@@ -81,7 +80,7 @@ contains
       info &
     )
     if (info /= 0) then
-      call log_message("LAPACK's zgbsv failed with info = " // str(info), level="error")
+      call logger%error("LAPACK's zgbsv failed with info = " // str(info))
       return
     end if
     call B_band%destroy()
@@ -92,7 +91,7 @@ contains
     ! allocate rwork array
     allocate(rwork(2 * N))
     ! get lwork
-    call log_message("calculating optimal length of work array", level="debug")
+    call logger%debug("calculating optimal length of work array")
     allocate(work(1))
     call zgeev( &
       "N", &
@@ -113,11 +112,11 @@ contains
     lwork = int(work(1))
     deallocate(work)
     ! allocate work array
-    call log_message("allocating work array with N = " // str(lwork), level="debug")
+    call logger%debug("allocating work array with N = " // str(lwork))
     allocate(work(lwork))
 
     ! solve eigenvalue problem
-    call log_message("solving evp using QR algorithm zgeev (LAPACK)", level="debug")
+    call logger%debug("solving evp using QR algorithm zgeev (LAPACK)")
     call zgeev( &
       "N", &
       jobvr, &
@@ -135,12 +134,8 @@ contains
       info &
     )
     if (info /= 0) then ! LCOV_EXCL_START
-      call log_message("LAPACK routine zgeev failed!", level="warning")
-      call log_message( &
-        "value for the info parameter: " // str(info), &
-        level="warning", &
-        use_prefix=.false. &
-      )
+      call logger%warning("LAPACK routine zgeev failed!")
+      call logger%warning("value for the info parameter: " // str(info))
     end if ! LCOV_EXCL_STOP
 
     ! tear down work arrays

--- a/src/solvers/smod_qz_direct.f08
+++ b/src/solvers/smod_qz_direct.f08
@@ -71,18 +71,14 @@ contains
     allocate(work(lwork))
 
     ! solve eigenvalue problem
-    call log_message("solving evp using QZ algorithm zggev (LAPACK)", level="debug")
+    call logger%debug("solving evp using QZ algorithm zggev (LAPACK)")
     call zggev3( &
       jobvl, jobvr, N, array_A, lda, array_B, ldb, &
       alpha, beta, vl, ldvl, vr, ldvr, work, lwork, rwork, info &
     )
     if (info /= 0) then ! LCOV_EXCL_START
-      call log_message("LAPACK routine zggev failed!", level="warning")
-      call log_message( &
-        "value for the info parameter: " // str(info), &
-        level="warning", &
-        use_prefix=.false. &
-      )
+      call logger%warning("LAPACK routine zggev failed!")
+      call logger%warning("value for the info parameter: " // str(info))
     end if ! LCOV_EXCL_STOP
     omega = alpha / beta
 

--- a/src/utils/mod_assert.f08
+++ b/src/utils/mod_assert.f08
@@ -3,7 +3,7 @@
 !! @note See [[assert.fpp]] for usage of the `assert` macro. The
 !! subroutine in this module should not be used directly. @endnote
 module mod_assert
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
 
   implicit none
 
@@ -25,10 +25,9 @@ contains
     !> The line of the assertion.
     integer,       intent(in) :: line
 
-    if (.not. cond) then
-        call log_message("assertion '" // cond_str // "' failed at " // &
-                       & file // ":" // str(line), level="error")
-    end if
+    if (.not. cond) call logger%error( &
+      "assertion '" // cond_str // "' failed at " //  file // ":" // str(line) &
+    )
   end subroutine assert
 
 end module mod_assert

--- a/src/utils/mod_get_indices.f08
+++ b/src/utils/mod_get_indices.f08
@@ -69,7 +69,7 @@ contains
   function transform_state_variable_to_subblock_index( &
     variables, state_vector, dim_subblock, odd, edge &
   ) result(idxs)
-    use mod_logging, only: log_message, str
+    use mod_logging, only: logger, str
 
     !> array of state vector variable names
     character(len=*), intent(in)  :: variables(:)
@@ -90,10 +90,9 @@ contains
     if (odd) idxs = idxs - 1
     if (edge == "right") idxs = idxs + dim_subblock
     if (size(idxs) == 0) then
-      call log_message( &
+      call logger%error( &
         "could not retrieve subblock indices for any variable in " // str(variables) &
-        // " for state vector " // str(state_vector), &
-        level="error" &
+        // " for state vector " // str(state_vector) &
       )
       return
     end if

--- a/src/utils/mod_timing.f08
+++ b/src/utils/mod_timing.f08
@@ -34,7 +34,7 @@
 !!```
 module mod_timing
   use mod_global_variables, only: dp
-  use mod_logging, only: log_message, str
+  use mod_logging, only: logger, str
   implicit none
 
   private
@@ -164,10 +164,9 @@ contains
     call system_clock(end_time, rate)
 
     elapsed_time = real(end_time - selected_start_time, kind=dp) / rate
-    call log_message( &
-      message // " (" // str(elapsed_time, fmt="f20.3") // " s)", &
-      level=loglevel &
-      )
+    call logger%debug( &
+      message // " (" // str(elapsed_time, fmt="f20.3") // " s)" &
+    )
   end subroutine toc
 
   !> Subroutine to start a CPU timer.
@@ -235,9 +234,8 @@ contains
     call cpu_time(end_time)
 
     elapsed_time = end_time - selected_start_time
-    call log_message( &
-      message // " (" // str(elapsed_time, fmt="f20.3") // " s, CPU time)", &
-      level=loglevel &
+    call logger%debug( &
+      message // " (" // str(elapsed_time, fmt="f20.3") // " s, CPU time)" &
     )
   end subroutine cputoc
 

--- a/src/utils/mod_timing.f08
+++ b/src/utils/mod_timing.f08
@@ -98,6 +98,7 @@ contains
     total_time = real(end_time - this%program_start_time, kind=dp) / rate
   end function get_total_time
 
+  ! LCOV_EXCL_START
 
   !> Subroutine to start a wall clock timer.
   !!
@@ -238,5 +239,7 @@ contains
       message // " (" // str(elapsed_time, fmt="f20.3") // " s, CPU time)" &
     )
   end subroutine cputoc
+
+  ! LCOV_EXCL_END
 
 end module mod_timing

--- a/tests/unit_tests/mod_suite_utils.f90
+++ b/tests/unit_tests/mod_suite_utils.f90
@@ -1,6 +1,7 @@
 module mod_suite_utils
   use mod_global_variables, only: dp
   use mod_settings, only: settings_t, new_settings
+  use mod_logging, only: logger
   implicit none
 
   real(dp), parameter :: TOL = 1.0d-12
@@ -15,12 +16,12 @@ contains
   end subroutine set_name
 
   subroutine reset_globals()
-    use mod_global_variables, only: initialise_globals, logging_level
+    use mod_global_variables, only: initialise_globals
     use mod_equilibrium_params, only: init_equilibrium_params, k2, k3
 
     call initialise_globals()
     call init_equilibrium_params()
-    logging_level = 1 ! also print warnings
+    call logger%set_logging_level(1)  ! also print warnings
     k2 = 1.0d0
     k3 = 2.5d0
   end subroutine reset_globals

--- a/tests/unit_tests/mod_test_eigenfunctions.pf
+++ b/tests/unit_tests/mod_test_eigenfunctions.pf
@@ -2,7 +2,6 @@ module mod_test_eigenfunctions
   use mod_suite_utils
   use funit
   use mod_eigenfunctions
-  use mod_global_variables
   use mod_types, only: ef_type
   implicit none
 
@@ -132,7 +131,7 @@ contains
   @test
   subroutine test_ef_names_derived_with_b01_field()
     call set_name("eigenfunctions - derived names (with B01)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call enable_derived_efs()
     call use_bfield(use_b01=.true.)
     @assertEqual(12, size(derived_ef_names))
@@ -209,8 +208,7 @@ contains
   @test
   subroutine test_eigenfunctions_pp_nonzero_B01()
     integer :: size_names_default
-
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_name("eigenfunctions - pp nonzero B01")
     call enable_derived_efs()
     size_names_default = size(derived_ef_names)
@@ -222,7 +220,6 @@ contains
   @test
   subroutine test_eigenfunctions_pp_with_bfield()
     integer :: size_names_default
-
     call set_name("eigenfunctions - pp names with bfield")
     call enable_derived_efs()
     size_names_default = size(derived_ef_names)

--- a/tests/unit_tests/mod_test_grid.pf
+++ b/tests/unit_tests/mod_test_grid.pf
@@ -51,11 +51,9 @@ contains
 
   @test
   subroutine test_cylindrical_grid_force_r0()
-    use mod_global_variables, only: logging_level
-
     call set_name("cylindrical grid, force r=0")
     settings%grid%force_r0 = .true.
-    logging_level = 0
+    call logger%set_logging_level(0)
     call create_test_grid(settings, 31, "cylindrical", 0.0d0, 2.0d0)
     @assertEqual(0.0d0, grid(1), tolerance=TOL)
     @assertEqual(2.0d0, grid(31), tolerance=TOL)

--- a/tests/unit_tests/mod_test_solar_atmosphere.pf
+++ b/tests/unit_tests/mod_test_solar_atmosphere.pf
@@ -2,7 +2,6 @@ module mod_test_solar_atmosphere
   use mod_suite_utils
   use funit
   use mod_solar_atmosphere, only: set_solar_atmosphere
-  use mod_global_variables, only: logging_level
   implicit none
 
   type(settings_t) :: settings
@@ -15,7 +14,6 @@ contains
     call create_test_grid(settings, 100, "Cartesian", 0.05d0, 0.35d0)
     call reset_fields(settings, init_fields=.true.)
     call set_default_units(settings)
-    logging_level = 1
   end subroutine init_test
 
 
@@ -184,7 +182,7 @@ contains
       unit_magneticfield=settings%units%get_unit_magneticfield(), &
       unit_length=5.0d6 &
     )
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings, n_interp=5000, load_from="test_sa_profiles/default" &
     )
@@ -200,7 +198,7 @@ contains
       unit_magneticfield=settings%units%get_unit_magneticfield(), &
       unit_length=settings%units%get_unit_length() &
     )
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings, n_interp=5000, load_from="test_sa_profiles/default" &
     )
@@ -216,7 +214,7 @@ contains
       unit_magneticfield=2.5d0, &
       unit_length=settings%units%get_unit_length() &
     )
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings, n_interp=5000, load_from="test_sa_profiles/default" &
     )
@@ -232,7 +230,7 @@ contains
       unit_magneticfield=settings%units%get_unit_magneticfield(), &
       unit_length=settings%units%get_unit_length() &
     )
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings, n_interp=5000, load_from="test_sa_profiles/default" &
     )
@@ -243,7 +241,7 @@ contains
   @test
   subroutine test_sa_loading_b02_inconsistent()
     call set_name("solar atmosphere (loading - B02 inconsistent)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings,  &
       f_b02=b02, &
@@ -273,7 +271,7 @@ contains
   @test
   subroutine test_sa_loading_db02_inconsistent()
     call set_name("solar atmosphere (loading - dB02 inconsistent)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings,  &
       f_b02=b02, &
@@ -303,7 +301,7 @@ contains
   @test
   subroutine test_sa_loading_b03_inconsistent()
     call set_name("solar atmosphere (loading - B03 inconsistent)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings,  &
       f_b03=b03, &
@@ -333,7 +331,7 @@ contains
   @test
   subroutine test_sa_loading_db03_inconsistent()
     call set_name("solar atmosphere (loading - dB03 inconsistent)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings,  &
       f_b03=b03, &
@@ -363,7 +361,7 @@ contains
   @test
   subroutine test_sa_loading_gravity_inconsistent()
     call set_name("solar atmosphere (loading - gravity inconsistent)")
-    logging_level = 0
+    call logger%set_logging_level(0)
     call set_solar_atmosphere( &
       settings,  &
       f_g=gprof, &


### PR DESCRIPTION
## PR description
The second PR in the refactoring and behaviour change series dedicated to Legolas 2.0.
Introduces a dedicated logger instead of a `log_message` subroutine for better control.
This PR is based upon #114 and should be rebased as soon as that one goes in.

```fortran
! before
call log_message("this is a message", level="info")
```
The new changes introduce type-bound procedures
```fortran
! after
call logger%info("this is info")
call logger%warning("this is a warning")
call logger%error("this raises an error")
```

## New features
**Legolas**
- The logging module now contains a `logger` object that can be used throughout the code
- Logging messages is now done through dedicated type-bound procedures instead of a single global subroutine with optional arguments.

## TODO
- [x] Rebase on #114 once that one is merged