### PR TITLE
Pylbo/save selection

### DIFF
--- a/post_processing/pylbo/file_handler.py
+++ b/post_processing/pylbo/file_handler.py
@@ -41,6 +41,8 @@ def load(datfile, display_info=True):
     ----------
     datfile : str, ~os.PathLike
         Path to the datfile.
+    display_info : bool
+        If `True`, datfile information is written to terminal.
 
     Raises
     ------
@@ -78,7 +80,7 @@ def load(datfile, display_info=True):
     return ds
 
 
-def load_series(datfiles):
+def load_series(datfiles, display_info=True):
     """
     Loads multiple Legolas datfiles.
 
@@ -87,6 +89,8 @@ def load_series(datfiles):
     datfiles : list, numpy.ndarray
         Paths to the datfiles that should be loaded, in list/array form. Every element
         should be a string or a ~os.PathLike object.
+    display_info : bool
+        If `True`, datfile information is written to terminal.
 
     Raises
     ------
@@ -105,70 +109,78 @@ def load_series(datfiles):
         _validate_file(datfile)
     series = LegolasDataSeries(datfiles)
 
-    # handle version printing
-    versions = [ds.legolas_version.parse() for ds in series.datasets]
-    minversion, maxversion = min(versions), max(versions)
-    if minversion == maxversion:
-        info_msg = str(minversion)
-    else:
-        info_msg = f"{minversion} --> {maxversion}"
-    pylboLogger.info(f"Legolas_version  : {info_msg}")
+    if display_info:
+        # handle version printing
+        versions = [ds.legolas_version.parse() for ds in series.datasets]
+        minversion, maxversion = min(versions), max(versions)
+        if minversion == maxversion:
+            info_msg = str(minversion)
+        else:
+            info_msg = f"{minversion} --> {maxversion}"
+        pylboLogger.info(f"Legolas_version  : {info_msg}")
 
-    # handle file information printing
-    names = sorted([ds.datfile.name for ds in series.datasets])
-    pylboLogger.info(f"files loaded     : {names[0]} --> {names[-1]}")
+        # handle file information printing
+        names = sorted([ds.datfile.name for ds in series.datasets])
+        pylboLogger.info(f"files loaded     : {names[0]} --> {names[-1]}")
 
-    # handle gridpoints printing
-    pts = [ds.gridpoints for ds in series.datasets]
-    minpts, maxpts = min(pts), max(pts)
-    if minpts == maxpts:
-        info_msg = str(minpts)
-    else:
-        info_msg = f"{minpts} --> {maxpts}"
-    pylboLogger.info(f"gridpoints       : {info_msg}")
+        # handle gridpoints printing
+        pts = [ds.gridpoints for ds in series.datasets]
+        minpts, maxpts = min(pts), max(pts)
+        if minpts == maxpts:
+            info_msg = str(minpts)
+        else:
+            info_msg = f"{minpts} --> {maxpts}"
+        pylboLogger.info(f"gridpoints       : {info_msg}")
 
-    # handle geometry printing
-    if not isinstance(series.geometry, str) and len(series.geometry) > 1:
-        pylboLogger.warning("multiple geometries detected!")
-    else:
-        pylboLogger.info(f"geometries       : {series.geometry}")
+        # handle geometry printing
+        if not isinstance(series.geometry, str) and len(series.geometry) > 1:
+            pylboLogger.warning("multiple geometries detected!")
+        else:
+            pylboLogger.info(f"geometries       : {series.geometry}")
 
-    # handle equilibrium printing
-    equils = set([ds.eq_type for ds in series.datasets])
-    if len(equils) > 1:
-        pylboLogger.error(f"multiple equilibria detected! -- {equils}")
-        raise ValueError
-    else:
-        pylboLogger.info(f"equilibria       : {equils.pop()}")
+        # handle equilibrium printing
+        equils = set([ds.eq_type for ds in series.datasets])
+        if len(equils) > 1:
+            pylboLogger.error(f"multiple equilibria detected! -- {equils}")
+            raise ValueError
+        else:
+            pylboLogger.info(f"equilibria       : {equils.pop()}")
 
-    # check presence of matrices
-    matrices_present = set([ds.header["matrices_written"] for ds in series.datasets])
-    if len(matrices_present) > 1:
-        pylboLogger.info("matrices present in some datfiles, but not all")
-    else:
-        if matrices_present.pop():
-            pylboLogger.info("matrices present in all datfiles")
+        # check presence of matrices
+        matrices_present = set(
+            [ds.header["matrices_written"] for ds in series.datasets]
+        )
+        if len(matrices_present) > 1:
+            pylboLogger.info("matrices present in some datfiles, but not all")
+        else:
+            if matrices_present.pop():
+                pylboLogger.info("matrices present in all datfiles")
 
-    # check presence of eigenfunctions
-    efs_present = set([ds.header["eigenfuncs_written"] for ds in series.datasets])
-    if len(efs_present) > 1:
-        pylboLogger.info("eigenfunctions present in some datfiles, but not all")
-    else:
-        if efs_present.pop():
-            pylboLogger.info("eigenfunctions present in all datfiles")
+        # check presence of eigenfunctions
+        efs_present = set([ds.header["eigenfuncs_written"] for ds in series.datasets])
+        if len(efs_present) > 1:
+            pylboLogger.info("eigenfunctions present in some datfiles, but not all")
+        else:
+            if efs_present.pop():
+                pylboLogger.info("eigenfunctions present in all datfiles")
 
-    # check presence of derived eigenfunctions
-    defs_present = set(
-        [ds.header.get("derived_eigenfuncs_written", False) for ds in series.datasets]
-    )
-    if len(defs_present) == 0:
-        pylboLogger.info("no derived eigenfunctions present")
-    elif len(defs_present) > 1:
-        pylboLogger.info("derived eigenfunctions present in some datfiles, but not all")
-    else:
-        if defs_present.pop():
-            pylboLogger.info("derived eigenfunctions present in all datfiles")
-    pylboLogger.info("-" * 75)
+        # check presence of derived eigenfunctions
+        defs_present = set(
+            [
+                ds.header.get("derived_eigenfuncs_written", False)
+                for ds in series.datasets
+            ]
+        )
+        if len(defs_present) == 0:
+            pylboLogger.info("no derived eigenfunctions present")
+        elif len(defs_present) > 1:
+            pylboLogger.info(
+                "derived eigenfunctions present in some datfiles, but not all"
+            )
+        else:
+            if defs_present.pop():
+                pylboLogger.info("derived eigenfunctions present in all datfiles")
+        pylboLogger.info("-" * 75)
     return series
 
 

--- a/post_processing/pylbo/file_handler.py
+++ b/post_processing/pylbo/file_handler.py
@@ -33,7 +33,7 @@ def _validate_file(file):
         raise InvalidLegolasFile(path_to_file)
 
 
-def load(datfile):
+def load(datfile, display_info=True):
     """
     Loads a single Legolas datfile.
 
@@ -56,24 +56,25 @@ def load(datfile):
         raise ValueError("load() takes a single datfile.")
     _validate_file(datfile)
     ds = LegolasDataSet(datfile)
-    pylboLogger.info(f"Legolas version  : {ds.legolas_version}")
-    pylboLogger.info(f"file loaded      : {ds.datfile.parent} -- {ds.datfile.name}")
-    pylboLogger.info(f"gridpoints       : {ds.gridpoints}")
-    pylboLogger.info(f"geometry         : {ds.geometry} in {ds.x_start, ds.x_end}")
-    pylboLogger.info(f"equilibrium      : {ds.eq_type}")
-    if ds.header["matrices_written"]:
-        pylboLogger.info("matrices present in datfile")
-    if ds.header["eigenfuncs_written"]:
-        pylboLogger.info("eigenfunctions present in datfile")
-    if ds.header.get("derived_eigenfuncs_written", False):
-        pylboLogger.info("derived eigenfunctions present in datfile")
-    if ds.header.get("eigenfunction_subset_used", False):
-        saved_efs = len(ds.header["ef_written_idxs"])
-        total_efs = len(ds.eigenvalues)
-        pylboLogger.info(
-            f"subset saved: {saved_efs}/{total_efs} eigenvalues have eigenfunctions"
-        )
-    pylboLogger.info("-" * 75)
+    if display_info:
+        pylboLogger.info(f"Legolas version  : {ds.legolas_version}")
+        pylboLogger.info(f"file loaded      : {ds.datfile.parent} -- {ds.datfile.name}")
+        pylboLogger.info(f"gridpoints       : {ds.gridpoints}")
+        pylboLogger.info(f"geometry         : {ds.geometry} in {ds.x_start, ds.x_end}")
+        pylboLogger.info(f"equilibrium      : {ds.eq_type}")
+        if ds.header["matrices_written"]:
+            pylboLogger.info("matrices present in datfile")
+        if ds.header["eigenfuncs_written"]:
+            pylboLogger.info("eigenfunctions present in datfile")
+        if ds.header.get("derived_eigenfuncs_written", False):
+            pylboLogger.info("derived eigenfunctions present in datfile")
+        if ds.header.get("eigenfunction_subset_used", False):
+            saved_efs = len(ds.header["ef_written_idxs"])
+            total_efs = len(ds.eigenvalues)
+            pylboLogger.info(
+                f"subset saved: {saved_efs}/{total_efs} eigenvalues have eigenfunctions"
+            )
+        pylboLogger.info("-" * 75)
     return ds
 
 

--- a/post_processing/pylbo/visualisation/eigenfunctions/eigfunc_interface.py
+++ b/post_processing/pylbo/visualisation/eigenfunctions/eigfunc_interface.py
@@ -145,8 +145,8 @@ class EigenfunctionInterface:
 
     def _save_eigenvalue_selection(self):
         """
-        Saves all selected eigenvalues and their eigenfunctions as a list of dictionaries
-        in a .npy file. Files can be loaded with the numpy load function.
+        Saves all selected eigenvalues and their eigenfunctions as a list of
+        dictionaries in a .npy file. Files can be loaded with the numpy load function.
         """
         if not self._selected_idxs:
             return
@@ -158,7 +158,7 @@ class EigenfunctionInterface:
                 point_to_store = ds.get_eigenfunctions(ev_idxs=int(point))[0]
                 to_store.append(point_to_store)
             filename = ds.datfile.name
-            filename = filename.replace('.dat', '')
+            filename = filename.replace(".dat", "")
             np.save(filename, to_store)
             print(f"{len(to_store)-1} mode(s) saved to " + filename + ".npy")
             count += 1
@@ -177,9 +177,11 @@ class EigenfunctionInterface:
             for point in self._selected_idxs[ds]:
                 to_store.append(int(point))
             filename = ds.datfile.name
-            filename = filename.replace('.dat', '')
+            filename = filename.replace(".dat", "")
             np.save(filename, to_store)
-            print(f"{len(self._selected_idxs[ds])} indices saved to " + filename + ".npy")
+            print(
+                f"{len(self._selected_idxs[ds])} indices saved to " + filename + ".npy"
+            )
             count += 1
 
     def _get_label(self, ds, ev_idx, w):

--- a/post_processing/pylbo/visualisation/eigenfunctions/eigfunc_interface.py
+++ b/post_processing/pylbo/visualisation/eigenfunctions/eigfunc_interface.py
@@ -143,6 +143,45 @@ class EigenfunctionInterface:
             idxs = np.array([int(idx) for idx in points.keys()])
             print(f"{ds.datfile.stem} | {ds.eigenvalues[idxs]}")
 
+    def _save_eigenvalue_selection(self):
+        """
+        Saves all selected eigenvalues and their eigenfunctions as a list of dictionaries
+        in a .npy file. Files can be loaded with the numpy load function.
+        """
+        if not self._selected_idxs:
+            return
+        count = 1
+        for ds in self._selected_idxs:
+            print(f"Saving selected eigenvalues for dataset {count}...")
+            to_store = [ds.ef_grid]
+            for point in self._selected_idxs[ds]:
+                point_to_store = ds.get_eigenfunctions(ev_idxs=int(point))[0]
+                to_store.append(point_to_store)
+            filename = ds.datfile.name
+            filename = filename.replace('.dat', '')
+            np.save(filename, to_store)
+            print(f"{len(to_store)-1} mode(s) saved to " + filename + ".npy")
+            count += 1
+
+    def _save_selection_indices(self):
+        """
+        Saves the indices of all selected eigenvalues as an array in a .npy file.
+        Files can be loaded with the numpy load function.
+        """
+        if not self._selected_idxs:
+            return
+        count = 1
+        for ds in self._selected_idxs:
+            print(f"Saving indices of selected eigenvalues for dataset {count}...")
+            to_store = []
+            for point in self._selected_idxs[ds]:
+                to_store.append(int(point))
+            filename = ds.datfile.name
+            filename = filename.replace('.dat', '')
+            np.save(filename, to_store)
+            print(f"{len(self._selected_idxs[ds])} indices saved to " + filename + ".npy")
+            count += 1
+
     def _get_label(self, ds, ev_idx, w):
         """
         Returns the label used in the legend. In case of a data series, the datfile
@@ -231,6 +270,10 @@ class EigenfunctionInterface:
             self._retransform_functions()
         elif event.key == "w":
             self._print_selected_eigenvalues()
+        elif event.key == "a":
+            self._save_eigenvalue_selection()
+        elif event.key == "j":
+            self._save_selection_indices()
         if event.key in ("enter", "up", "down", "i", "t"):
             self.update_plot()
         event.canvas.draw()
@@ -409,6 +452,8 @@ class EigenfunctionInterface:
             [r"$\mathbf{t}$", r"cylindrical: toggle $v_r \leftrightarrow r v_r$"],
             [r"$\mathbf{w}$", r"print selected $\omega$ to console"],
             [r"$\mathbf{e}$", r"subset: toggle center and radius"],
+            [r"$\mathbf{a}$", r"save eigenvalue selection"],
+            [r"$\mathbf{j}$", r"save selection indices"],
         ]
         bbox = np.array([0.1, 0.3, 0.8, 0.4])
         rectangle = patches.Rectangle(


### PR DESCRIPTION
## PR description
When interactively viewing a spectrum with Pylbo, selected eigenvalues and their eigenfunctions (or indices) can be saved to a `.npy` file for further analysis.

## New features
**Pylbo**
- Introduction of optional argument `display_info` in the `load` and `load_series` functions to turn of writing datfile information to terminal.
- Keypress function `_save_eigenvalue_selection` to save interactively selected eigenvalues and their eigenfunctions to a `.npy` file.
- Keypress function `_save_selection_indices` to save the indices of interactively selected eigenvalues to a `.npy` file.

## Checklist
- [x] all tests pass (and for new features, new tests are added)
- [x] documentation has been updated (if applicable)
