### PR TITLE
Refactor grid into dedicated object

### DIFF
--- a/src/boundaries/mod_boundary_manager.f08
+++ b/src/boundaries/mod_boundary_manager.f08
@@ -6,6 +6,7 @@ module mod_boundary_manager
   use mod_settings, only: settings_t
   use mod_background, only: background_t
   use mod_physics, only: physics_t
+  use mod_grid, only: grid_t
   implicit none
 
   private
@@ -29,19 +30,21 @@ module mod_boundary_manager
     end subroutine apply_essential_boundaries_right
 
     module subroutine apply_natural_boundaries_left( &
-      matrix, settings, background, physics &
+      matrix, settings, grid, background, physics &
     )
       type(matrix_t), intent(inout) :: matrix
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine apply_natural_boundaries_left
 
     module subroutine apply_natural_boundaries_right( &
-      matrix, settings, background, physics &
+      matrix, settings, grid, background, physics &
     )
       type(matrix_t), intent(inout) :: matrix
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine apply_natural_boundaries_right
@@ -52,7 +55,7 @@ module mod_boundary_manager
 contains
 
   subroutine apply_boundary_conditions( &
-    matrix_A, matrix_B, settings, background, physics &
+    matrix_A, matrix_B, settings, grid, background, physics &
   )
     !> the A-matrix with boundary conditions imposed on exit
     type(matrix_t), intent(inout) :: matrix_A
@@ -60,22 +63,23 @@ contains
     type(matrix_t), intent(inout) :: matrix_B
     !> the settings object
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
 
     call set_boundary_flags(settings)
 
     ! handle left side boundary conditions B-matrix
-    call apply_natural_boundaries_left(matrix_B, settings, background, physics)
+    call apply_natural_boundaries_left(matrix_B, settings, grid, background, physics)
     call apply_essential_boundaries_left(matrix_B, settings)
     ! handle left side boundary conditions A-matrix
-    call apply_natural_boundaries_left(matrix_A, settings, background, physics)
+    call apply_natural_boundaries_left(matrix_A, settings, grid, background, physics)
     call apply_essential_boundaries_left(matrix_A, settings)
     ! handle right side boundary conditions B-matrix
-    call apply_natural_boundaries_right(matrix_B, settings, background, physics)
+    call apply_natural_boundaries_right(matrix_B, settings, grid, background, physics)
     call apply_essential_boundaries_right(matrix_B, settings)
     ! handle right side boundary conditions A-matrix
-    call apply_natural_boundaries_right(matrix_A, settings, background, physics)
+    call apply_natural_boundaries_right(matrix_A, settings, grid, background, physics)
     call apply_essential_boundaries_right(matrix_A, settings)
   end subroutine apply_boundary_conditions
 

--- a/src/boundaries/smod_natural_bounds_conduction.f08
+++ b/src/boundaries/smod_natural_bounds_conduction.f08
@@ -10,16 +10,14 @@ contains
     real(dp) :: kappa_perp
     real(dp) :: dkappa_perp_drho, dkappa_perp_dT
     real(dp) :: gamma_1
-    real(dp) :: x
     type(matrix_elements_t) :: elements
 
     if (.not. settings%physics%conduction%is_enabled()) return
 
-    x = grid_gauss(grid_idx)
 
     gamma_1 = settings%physics%get_gamma_1()
-    eps = eps_grid(grid_idx)
-    deps = d_eps_grid_dr(grid_idx)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
     dT0 = background%temperature%dT0(x)
     dkappa_para_dT = physics%conduction%dtcparadT(x)
     kappa_perp = physics%conduction%tcperp(x)
@@ -49,7 +47,9 @@ contains
     )
 
     if (settings%has_bfield()) then
-      call add_natural_conduction_terms_bfield(settings, background, physics, elements)
+      call add_natural_conduction_terms_bfield( &
+        x, settings, grid, background, physics, elements &
+      )
     end if
 
     call add_to_quadblock(quadblock, elements, weight, settings%dims)
@@ -58,9 +58,11 @@ contains
 
 
   subroutine add_natural_conduction_terms_bfield( &
-    settings, background, physics, elements &
+    x, settings, grid, background, physics, elements &
   )
+    real(dp), intent(in) :: x
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
     type(matrix_elements_t), intent(inout) :: elements
@@ -73,12 +75,10 @@ contains
     real(dp) :: dkappa_perp_drho, dkappa_perp_dT, dkappa_perp_dB2
     real(dp) :: Fop, Gop_min, Kp, Kp_plus, Kp_plusplus
     real(dp) :: gamma_1
-    real(dp) :: x
 
     gamma_1 = settings%physics%get_gamma_1()
-    eps = eps_grid(grid_idx)
-    deps = d_eps_grid_dr(grid_idx)
-    x = grid_gauss(grid_idx)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
     dT0 = background%temperature%dT0(x)
     dkappa_para_dT = physics%conduction%dtcparadT(x)
     kappa_perp = physics%conduction%tcperp(x)

--- a/src/boundaries/smod_natural_bounds_flow.f08
+++ b/src/boundaries/smod_natural_bounds_flow.f08
@@ -10,8 +10,8 @@ contains
 
     if (.not. settings%physics%flow%is_enabled()) return
 
-    rho = background%density%rho0(grid_gauss(grid_idx))
-    v01 = background%velocity%v01(grid_gauss(grid_idx))
+    rho = background%density%rho0(x)
+    v01 = background%velocity%v01(x)
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
     ! ==================== Cubic * Cubic ====================

--- a/src/boundaries/smod_natural_bounds_hall.f08
+++ b/src/boundaries/smod_natural_bounds_hall.f08
@@ -7,15 +7,13 @@ contains
     real(dp)  :: eps
     real(dp)  :: rho
     real(dp)  :: eta_e
-    real(dp) :: x
     type(matrix_elements_t) :: elements
 
     if (.not. settings%physics%hall%is_enabled()) return
     if (.not. settings%physics%hall%has_electron_inertia()) return
 
-    x = grid_gauss(grid_idx)
-    eps = eps_grid(grid_idx)
-    rho = background%density%rho0(grid_gauss(grid_idx))
+    eps = grid%get_eps(x)
+    rho = background%density%rho0(x)
     eta_e = physics%hall%inertiafactor(x)
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
@@ -38,16 +36,14 @@ contains
     real(dp)  :: eps, deps
     real(dp)  :: rho, T0, B01, B02, B03
     real(dp)  :: eta_H, mu, efrac
-    real(dp) :: x
     type(matrix_elements_t) :: elements
 
     if (.not. settings%physics%hall%is_enabled()) return
     ! Hall by substitution of the momentum equation, only contains viscosity terms
     if (.not. settings%physics%viscosity%is_enabled()) return
 
-    eps = eps_grid(grid_idx)
-    deps = d_eps_grid_dr(grid_idx)
-    x = grid_gauss(grid_idx)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
 
     rho = background%density%rho0(x)
     T0 = background%temperature%T0(x)

--- a/src/boundaries/smod_natural_bounds_regular.f08
+++ b/src/boundaries/smod_natural_bounds_regular.f08
@@ -10,12 +10,12 @@ contains
     real(dp)  :: Gop_min
     type(matrix_elements_t) :: elements
 
-    eps = eps_grid(grid_idx)
-    rho = background%density%rho0(grid_gauss(grid_idx))
-    T0 = background%temperature%T0(grid_gauss(grid_idx))
-    B01 = background%magnetic%B01(grid_gauss(grid_idx))
-    B02 = background%magnetic%B02(grid_gauss(grid_idx))
-    B03 = background%magnetic%B03(grid_gauss(grid_idx))
+    eps = grid%get_eps(x)
+    rho = background%density%rho0(x)
+    T0 = background%temperature%T0(x)
+    B01 = background%magnetic%B01(x)
+    B02 = background%magnetic%B02(x)
+    B03 = background%magnetic%B03(x)
     Gop_min = k3 * B02 - k2 * B03 / eps
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 

--- a/src/boundaries/smod_natural_bounds_resistive.f08
+++ b/src/boundaries/smod_natural_bounds_resistive.f08
@@ -9,16 +9,14 @@ contains
     real(dp)  :: B02, dB02, drB02
     real(dp)  :: B03, dB03
     real(dp) :: gamma_1
-    real(dp) :: x
     type(matrix_elements_t) :: elements
 
     if (.not. settings%physics%resistivity%is_enabled()) return
 
     gamma_1 = settings%physics%get_gamma_1()
 
-    eps = eps_grid(grid_idx)
-    deps = d_eps_grid_dr(grid_idx)
-    x = grid_gauss(grid_idx)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
     eta = physics%resistivity%eta(x)
     B02 = background%magnetic%B02(x)
     dB02 = background%magnetic%dB02(x)

--- a/src/boundaries/smod_natural_bounds_viscosity.f08
+++ b/src/boundaries/smod_natural_bounds_viscosity.f08
@@ -18,11 +18,11 @@ contains
     is_compressible = .not. settings%physics%is_incompressible
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
-    eps = eps_grid(grid_idx)
-    deps = d_eps_grid_dr(grid_idx)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
     mu = settings%physics%viscosity%get_viscosity_value()
-    dv01 = background%velocity%dv01(grid_gauss(grid_idx))
-    dv03 = background%velocity%dv03(grid_gauss(grid_idx))
+    dv01 = background%velocity%dv01(x)
+    dv03 = background%velocity%dv03(x)
 
     ! ==================== Cubic * Cubic ====================
     call elements%add( &

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -1,6 +1,7 @@
 module mod_output
   use mod_global_variables, only: dp, str_len, str_len_arr
   use mod_settings, only: settings_t
+  use mod_grid, only: grid_t
   use mod_background, only: background_t
   use mod_physics, only: physics_t
   use mod_matrix_structure, only: matrix_t
@@ -54,6 +55,7 @@ contains
 
   subroutine create_datfile( &
     settings, &
+    grid, &
     background, &
     physics, &
     eigenvalues, &
@@ -63,9 +65,9 @@ contains
     eigenfunctions &
   )
     use mod_version, only: LEGOLAS_VERSION
-    use mod_grid, only: grid, grid_gauss
 
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
     complex(dp), intent(in) :: eigenvalues(:)
@@ -83,8 +85,8 @@ contains
     call write_header(settings)
 
     write(dat_fh) size(eigenvalues), eigenvalues
-    write(dat_fh) grid, grid_gauss
-    call write_equilibrium_data(settings, background, physics)
+    write(dat_fh) grid%base_grid, grid%gaussian_grid
+    call write_equilibrium_data(settings, grid, background, physics)
     if (settings%io%write_eigenfunctions) then
       call write_base_eigenfunction_data(eigenfunctions)
     end if
@@ -330,48 +332,48 @@ contains
   end subroutine write_equilibrium_names
 
 
-  subroutine write_equilibrium_data(settings, background, physics)
-    use mod_grid, only: grid_gauss
+  subroutine write_equilibrium_data(settings, grid, background, physics)
     use mod_function_utils, only: from_function
 
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
 
-    write(dat_fh) from_function(background%density%rho0, grid_gauss)
-    write(dat_fh) from_function(background%density%drho0, grid_gauss)
-    write(dat_fh) from_function(background%temperature%T0, grid_gauss)
-    write(dat_fh) from_function(background%temperature%dT0, grid_gauss)
-    write(dat_fh) from_function(background%temperature%ddT0, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%B01, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%B02, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%B03, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%dB02, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%db03, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%ddB02, grid_gauss)
-    write(dat_fh) from_function(background%magnetic%ddb03, grid_gauss)
-    write(dat_fh) background%magnetic%get_B0(grid_gauss)
-    write(dat_fh) from_function(background%velocity%v01, grid_gauss)
-    write(dat_fh) from_function(background%velocity%v02, grid_gauss)
-    write(dat_fh) from_function(background%velocity%v03, grid_gauss)
-    write(dat_fh) from_function(background%velocity%dv01, grid_gauss)
-    write(dat_fh) from_function(background%velocity%dv02, grid_gauss)
-    write(dat_fh) from_function(background%velocity%dv03, grid_gauss)
-    write(dat_fh) from_function(background%velocity%ddv01, grid_gauss)
-    write(dat_fh) from_function(background%velocity%ddv02, grid_gauss)
-    write(dat_fh) from_function(background%velocity%ddv03, grid_gauss)
+    write(dat_fh) from_function(background%density%rho0, grid%gaussian_grid)
+    write(dat_fh) from_function(background%density%drho0, grid%gaussian_grid)
+    write(dat_fh) from_function(background%temperature%T0, grid%gaussian_grid)
+    write(dat_fh) from_function(background%temperature%dT0, grid%gaussian_grid)
+    write(dat_fh) from_function(background%temperature%ddT0, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%B01, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%B02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%B03, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%dB02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%db03, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%ddB02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%magnetic%ddb03, grid%gaussian_grid)
+    write(dat_fh) background%magnetic%get_B0(grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%v01, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%v02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%v03, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%dv01, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%dv02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%dv03, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%ddv01, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%ddv02, grid%gaussian_grid)
+    write(dat_fh) from_function(background%velocity%ddv03, grid%gaussian_grid)
 
-    write(dat_fh) from_function(physics%cooling%L0, grid_gauss)
-    write(dat_fh) from_function(physics%cooling%dLdT, grid_gauss)
-    write(dat_fh) from_function(physics%cooling%dLdrho, grid_gauss)
-    write(dat_fh) from_function(physics%conduction%tcpara, grid_gauss)
-    write(dat_fh) from_function(physics%conduction%tcperp, grid_gauss)
-    write(dat_fh) from_function(physics%resistivity%eta, grid_gauss)
-    write(dat_fh) from_function(physics%resistivity%detadT, grid_gauss)
-    write(dat_fh) from_function(physics%resistivity%detadr, grid_gauss)
-    write(dat_fh) from_function(physics%gravity%g0, grid_gauss)
-    write(dat_fh) from_function(physics%hall%hallfactor, grid_gauss)
-    write(dat_fh) from_function(physics%hall%inertiafactor, grid_gauss)
+    write(dat_fh) from_function(physics%cooling%L0, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%cooling%dLdT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%cooling%dLdrho, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%conduction%tcpara, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%conduction%tcperp, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%resistivity%eta, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%resistivity%detadT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%resistivity%detadr, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%gravity%g0, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%hall%hallfactor, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%hall%inertiafactor, grid%gaussian_grid)
   end subroutine write_equilibrium_data
 
 

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -88,7 +88,7 @@ contains
     write(dat_fh) grid%base_grid, grid%gaussian_grid
     call write_equilibrium_data(settings, grid, background, physics)
     if (settings%io%write_eigenfunctions) then
-      call write_base_eigenfunction_data(eigenfunctions)
+      call write_base_eigenfunction_data(grid, eigenfunctions)
     end if
     if (settings%io%write_derived_eigenfunctions) then
       call write_derived_eigenfunction_data(settings, eigenfunctions)
@@ -377,12 +377,13 @@ contains
   end subroutine write_equilibrium_data
 
 
-  subroutine write_base_eigenfunction_data(eigenfunctions)
+  subroutine write_base_eigenfunction_data(grid, eigenfunctions)
+    type(grid_t), intent(in) :: grid
     type(eigenfunctions_t), intent(in) :: eigenfunctions
     integer :: i
 
     call logger%info("writing eigenfunctions...")
-    write(dat_fh) size(eigenfunctions%ef_grid), eigenfunctions%ef_grid
+    write(dat_fh) size(grid%ef_grid), grid%ef_grid
     write(dat_fh) size(eigenfunctions%ef_written_flags), eigenfunctions%ef_written_flags
     write(dat_fh) size(eigenfunctions%ef_written_idxs), eigenfunctions%ef_written_idxs
     do i = 1, size(eigenfunctions%base_efs)

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -18,7 +18,6 @@ module mod_eigenfunctions
     type(derived_ef_t), allocatable :: derived_efs(:)
     logical, allocatable :: ef_written_flags(:)
     integer, allocatable :: ef_written_idxs(:)
-    real(dp), allocatable :: ef_grid(:)
 
   contains
 
@@ -124,7 +123,6 @@ contains
     end if
     if (allocated(this%ef_written_flags)) deallocate(this%ef_written_flags)
     if (allocated(this%ef_written_idxs)) deallocate(this%ef_written_idxs)
-    if (allocated(this%ef_grid)) deallocate(this%ef_grid)
     nullify(this%settings)
     nullify(this%background)
     nullify(this%grid)

--- a/src/eigenfunctions/mod_eigenfunctions.f08
+++ b/src/eigenfunctions/mod_eigenfunctions.f08
@@ -2,6 +2,7 @@ module mod_eigenfunctions
   use mod_global_variables, only: dp
   use mod_settings, only: settings_t
   use mod_background, only: background_t
+  use mod_grid, only: grid_t
   use mod_base_efs, only: base_ef_t
   use mod_derived_efs, only: derived_ef_t, deallocate_derived_ef_module_variables
   use mod_derived_ef_names, only: create_and_set_derived_state_vector
@@ -11,6 +12,7 @@ module mod_eigenfunctions
 
   type, public :: eigenfunctions_t
     type(settings_t), pointer, private :: settings
+    type(grid_t), pointer, private :: grid
     type(background_t), pointer, private :: background
     type(base_ef_t), allocatable :: base_efs(:)
     type(derived_ef_t), allocatable :: derived_efs(:)
@@ -31,11 +33,13 @@ module mod_eigenfunctions
 
 contains
 
-  function new_eigenfunctions(settings, background) result(eigenfunctions)
+  function new_eigenfunctions(settings, grid, background) result(eigenfunctions)
     type(settings_t), target, intent(inout) :: settings
+    type(grid_t), target, intent(in) :: grid
     type(background_t), target, intent(in) :: background
     type(eigenfunctions_t) :: eigenfunctions
     eigenfunctions%settings => settings
+    eigenfunctions%grid => grid
     eigenfunctions%background => background
   end function new_eigenfunctions
 
@@ -48,14 +52,13 @@ contains
     integer :: i, nb_efs
 
     call this%select_eigenfunctions_to_save(omega)
-    this%ef_grid = get_ef_grid(this%settings)
     state_vector = this%settings%get_state_vector()
     nb_efs = size(this%ef_written_idxs)
 
     allocate(this%base_efs(size(state_vector)))
     do i = 1, size(this%base_efs)
       call this%base_efs(i)%initialise( &
-        name=state_vector(i), ef_grid_size=size(this%ef_grid), nb_efs=nb_efs &
+        name=state_vector(i), ef_grid_size=size(this%grid%ef_grid), nb_efs=nb_efs &
       )
     end do
     deallocate(state_vector)
@@ -69,7 +72,7 @@ contains
     do i = 1, size(this%derived_efs)
       call this%derived_efs(i)%initialise( &
         name=derived_state_vector(i), &
-        ef_grid_size=size(this%ef_grid), &
+        ef_grid_size=size(this%grid%ef_grid), &
         nb_efs=nb_efs &
       )
     end do
@@ -84,9 +87,9 @@ contains
     do i = 1, size(this%base_efs)
       call this%base_efs(i)%assemble( &
         settings=this%settings, &
+        grid=this%grid, &
         idxs_to_assemble=this%ef_written_idxs, &
-        right_eigenvectors=right_eigenvectors, &
-        ef_grid=this%ef_grid &
+        right_eigenvectors=right_eigenvectors &
       )
     end do
 
@@ -94,10 +97,10 @@ contains
     do i = 1, size(this%derived_efs)
       call this%derived_efs(i)%assemble( &
         settings=this%settings, &
+        grid=this%grid, &
         background=this%background, &
         idxs_to_assemble=this%ef_written_idxs, &
-        right_eigenvectors=right_eigenvectors, &
-        ef_grid=this%ef_grid &
+        right_eigenvectors=right_eigenvectors &
       )
     end do
     call deallocate_derived_ef_module_variables()
@@ -122,6 +125,9 @@ contains
     if (allocated(this%ef_written_flags)) deallocate(this%ef_written_flags)
     if (allocated(this%ef_written_idxs)) deallocate(this%ef_written_idxs)
     if (allocated(this%ef_grid)) deallocate(this%ef_grid)
+    nullify(this%settings)
+    nullify(this%background)
+    nullify(this%grid)
   end subroutine delete
 
 
@@ -162,24 +168,5 @@ contains
       distance_from_subset_center <= radius &
     )
   end function eigenvalue_is_inside_subset_radius
-
-
-  pure function get_ef_grid(settings) result(ef_grid)
-    use mod_grid, only: grid
-    type(settings_t), intent(in) :: settings
-    real(dp), allocatable :: ef_grid(:)
-    integer :: grid_idx
-
-    allocate(ef_grid(settings%grid%get_ef_gridpts()))
-    ! first gridpoint, left edge
-    ef_grid(1) = grid(1)
-    ! other gridpoints
-    do grid_idx = 1, settings%grid%get_gridpts() - 1
-      ! position of center point in grid interval
-      ef_grid(2 * grid_idx) = 0.5_dp * (grid(grid_idx) + grid(grid_idx + 1))
-      ! position of end point in grid interval
-      ef_grid(2 * grid_idx + 1) = grid(grid_idx + 1)
-    end do
-  end function get_ef_grid
 
 end module mod_eigenfunctions

--- a/src/equilibria/smod_equil_KHI.f08
+++ b/src/equilibria/smod_equil_KHI.f08
@@ -50,7 +50,7 @@ contains
       tau = 11.0_dp
     end if ! LCOV_EXCL_STOP
 
-    call flow_driven_instabilities_eq(settings, background, physics)
+    call flow_driven_instabilities_eq(settings, grid, background, physics)
     ! manually force the magnetic field to zero, it's HD here (the above set
     ! of parameters still yield a B03 component)
     call background%set_magnetic_2_funcs(B02_func=zero_func, dB02_func=zero_func)

--- a/src/equilibria/smod_equil_MRI_accretion.f08
+++ b/src/equilibria/smod_equil_MRI_accretion.f08
@@ -47,7 +47,6 @@ contains
       tau = 1.0_dp
       nu = 0.1_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     mu1 = tau
     epsilon = nu

--- a/src/equilibria/smod_equil_RTI.f08
+++ b/src/equilibria/smod_equil_RTI.f08
@@ -50,7 +50,7 @@ contains
       tau = 0.0_dp
     end if ! LCOV_EXCL_STOP
 
-    call flow_driven_instabilities_eq(settings, background, physics)
+    call flow_driven_instabilities_eq(settings, grid, background, physics)
   end procedure RTI_eq
 
 end submodule smod_equil_RTI

--- a/src/equilibria/smod_equil_RTI_KHI.f08
+++ b/src/equilibria/smod_equil_RTI_KHI.f08
@@ -50,7 +50,7 @@ contains
       tau = 4.0_dp
     end if ! LCOV_EXCL_STOP
 
-    call flow_driven_instabilities_eq(settings, background, physics)
+    call flow_driven_instabilities_eq(settings, grid, background, physics)
   end procedure RTI_KHI_eq
 
 end submodule smod_equil_RTI_KHI

--- a/src/equilibria/smod_equil_RTI_theta_pinch.f08
+++ b/src/equilibria/smod_equil_RTI_theta_pinch.f08
@@ -53,7 +53,6 @@ contains
       k3 = 0.0_dp
     end if ! LCOV_EXCL_STOP
 
-    call initialise_grid(settings)
     width = settings%grid%get_grid_end() - settings%grid%get_grid_start()
     cte_p0 = 0.5_dp * (1.0_dp - delta)**2
     B_inf = width * sqrt(cte_rho0)

--- a/src/equilibria/smod_equil_adiabatic_homo.f08
+++ b/src/equilibria/smod_equil_adiabatic_homo.f08
@@ -19,7 +19,6 @@ contains
 
   !> Sets the equilibrium.
   module procedure adiabatic_homo_eq
-
     if (settings%equilibrium%use_defaults) then ! LCOV_EXCL_START
       call settings%grid%set_geometry("Cartesian")
       call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
@@ -31,7 +30,6 @@ contains
       cte_B02 = 0.0_dp
       cte_B03 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0)

--- a/src/equilibria/smod_equil_constant_current.f08
+++ b/src/equilibria/smod_equil_constant_current.f08
@@ -33,7 +33,6 @@ contains
       cte_rho0 = 1.0_dp
       cte_B03 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0, dT0_func=dT0)

--- a/src/equilibria/smod_equil_coronal_flux_tube.f08
+++ b/src/equilibria/smod_equil_coronal_flux_tube.f08
@@ -96,7 +96,7 @@ contains
       end if
       custom_grid(i) = custom_grid(i - 1) + dx
     end do
-    call initialise_grid(settings, custom_grid=custom_grid)
+    call grid%set_custom_grid(custom_grid)
     deallocate(custom_grid)
 
     rho_e = 4.0_dp * (2.0_dp * gamma + 1.0_dp) * cte_rho0 / (50.0_dp * gamma + 1.0_dp)
@@ -113,7 +113,6 @@ contains
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0)
     call background%set_magnetic_3_funcs(B03_func=B03)
-
   end procedure coronal_flux_tube_eq
 
 

--- a/src/equilibria/smod_equil_couette_flow.f08
+++ b/src/equilibria/smod_equil_couette_flow.f08
@@ -37,7 +37,6 @@ contains
       call settings%physics%enable_viscosity(viscosity_value=0.001_dp)
     end if ! LCOV_EXCL_STOP
 
-    call initialise_grid(settings)
     width = settings%grid%get_grid_end() - settings%grid%get_grid_start()
 
     call background%set_density_funcs(rho0_func=rho0)

--- a/src/equilibria/smod_equil_discrete_alfven.f08
+++ b/src/equilibria/smod_equil_discrete_alfven.f08
@@ -51,7 +51,6 @@ contains
       k3 = 0.05_dp
     end if ! LCOV_EXCL_STOP
 
-    call initialise_grid(settings)
     x_end = settings%grid%get_grid_end()
 
     call background%set_density_funcs(rho0_func=rho0, drho0_func=drho0)

--- a/src/equilibria/smod_equil_flow_driven_instabilities.f08
+++ b/src/equilibria/smod_equil_flow_driven_instabilities.f08
@@ -20,7 +20,6 @@ contains
   module procedure flow_driven_instabilities_eq
     call settings%grid%set_geometry("Cartesian")
     call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
-    call initialise_grid(settings)
     call settings%physics%enable_flow()
     v0 = p1
     v1 = p2

--- a/src/equilibria/smod_equil_gold_hoyle.f08
+++ b/src/equilibria/smod_equil_gold_hoyle.f08
@@ -75,13 +75,11 @@ contains
       !   mean_molecular_weight=1.0_dp & ! pure proton plasma
       ! )
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0)
     call background%set_magnetic_2_funcs(B02_func=B02, dB02_func=dB02)
     call background%set_magnetic_3_funcs(B03_func=B03, dB03_func=dB03)
-
   end procedure gold_hoyle_eq
 
 

--- a/src/equilibria/smod_equil_gravito_acoustic.f08
+++ b/src/equilibria/smod_equil_gravito_acoustic.f08
@@ -34,7 +34,6 @@ contains
       alpha = 20.42_dp
       g = 0.5_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     cte_rho0 = alpha * cte_p0 / g
 
@@ -42,7 +41,6 @@ contains
     call background%set_temperature_funcs(T0_func=T0)
 
     call physics%set_gravity_funcs(g0_func=g0)
-
   end procedure gravito_acoustic_eq
 
 

--- a/src/equilibria/smod_equil_gravito_mhd.f08
+++ b/src/equilibria/smod_equil_gravito_mhd.f08
@@ -40,9 +40,6 @@ contains
     beta  = 2.0_dp * cte_p0 / B0**2
     cte_rho0 = (alpha / g) * (cte_p0 + 0.5_dp * B0**2)
 
-    call initialise_grid(settings)
-
-
     call background%set_density_funcs(rho0_func=rho0, drho0_func=drho0)
     call background%set_temperature_funcs(T0_func=T0)
     call background%set_magnetic_3_funcs(B03_func=B03, dB03_func=dB03)

--- a/src/equilibria/smod_equil_harris_sheet.f08
+++ b/src/equilibria/smod_equil_harris_sheet.f08
@@ -42,7 +42,6 @@ contains
       !> eq_bool >> if True, the alternative force-free Harris sheet is used
       eq_bool = .false.
     end if
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0, dT0_func=dT0)

--- a/src/equilibria/smod_equil_interchange_modes.f08
+++ b/src/equilibria/smod_equil_interchange_modes.f08
@@ -39,7 +39,6 @@ contains
       lambda = 0.0_dp
       alpha = 20.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     B0 = 1.0_dp
     beta = 2.0_dp*cte_p0 / B0**2

--- a/src/equilibria/smod_equil_internal_kink_instability.f08
+++ b/src/equilibria/smod_equil_internal_kink_instability.f08
@@ -27,7 +27,6 @@ contains
   module procedure internal_kink_eq
     call settings%grid%set_geometry("cylindrical")
     call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
-    call initialise_grid(settings)
 
     a0 = settings%grid%get_grid_end()
     if (settings%equilibrium%use_defaults) then ! LCOV_EXCL_START

--- a/src/equilibria/smod_equil_isothermal_atmosphere.f08
+++ b/src/equilibria/smod_equil_isothermal_atmosphere.f08
@@ -44,7 +44,6 @@ contains
       k2 = 0.0_dp
       k3 = 2.0_dp
     end if  ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     scale_height = cte_T0 / g
 

--- a/src/equilibria/smod_equil_kelvin_helmholtz_cd.f08
+++ b/src/equilibria/smod_equil_kelvin_helmholtz_cd.f08
@@ -49,7 +49,6 @@ contains
 
     call settings%grid%set_geometry("cylindrical")
     call settings%grid%set_grid_boundaries(0.0_dp, 2.0_dp * rj)
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_velocity_3_funcs(v03_func=v03, dv03_func=dv03)

--- a/src/equilibria/smod_equil_magnetothermal_instabilities.f08
+++ b/src/equilibria/smod_equil_magnetothermal_instabilities.f08
@@ -48,7 +48,6 @@ contains
       k2 = 0.0_dp
       k3 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0, drho0_func=drho0)
     call background%set_temperature_funcs(T0_func=T0)

--- a/src/equilibria/smod_equil_photospheric_flux_tube.f08
+++ b/src/equilibria/smod_equil_photospheric_flux_tube.f08
@@ -97,7 +97,7 @@ contains
       end if
       custom_grid(i) = custom_grid(i - 1) + dx
     end do
-    call initialise_grid(settings, custom_grid=custom_grid)
+    call grid%set_custom_grid(custom_grid)
     deallocate(custom_grid)
 
     rho_e = 8.0_dp * (2.0_dp * gamma + 1.0_dp) * cte_rho0 / (gamma + 18.0_dp)

--- a/src/equilibria/smod_equil_resistive_homo.f08
+++ b/src/equilibria/smod_equil_resistive_homo.f08
@@ -36,7 +36,6 @@ contains
       cte_B02 = 0.0_dp
       cte_B03 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0)

--- a/src/equilibria/smod_equil_resistive_tearing.f08
+++ b/src/equilibria/smod_equil_resistive_tearing.f08
@@ -36,7 +36,6 @@ contains
       beta = 0.15_dp
       cte_rho0 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_temperature_funcs(T0_func=T0)

--- a/src/equilibria/smod_equil_resistive_tearing_flow.f08
+++ b/src/equilibria/smod_equil_resistive_tearing_flow.f08
@@ -36,7 +36,6 @@ contains
       beta = 0.15_dp
       cte_rho0 = 1.0_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_velocity_2_funcs(v02_func=v02, dv02_func=dv02)

--- a/src/equilibria/smod_equil_resonant_absorption.f08
+++ b/src/equilibria/smod_equil_resonant_absorption.f08
@@ -53,7 +53,6 @@ contains
       rho_left = p1
       rho_right = p2
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
     x_start = settings%grid%get_grid_start()
     x_end = settings%grid%get_grid_end()
 

--- a/src/equilibria/smod_equil_rotating_plasma_cylinder.f08
+++ b/src/equilibria/smod_equil_rotating_plasma_cylinder.f08
@@ -52,7 +52,6 @@ contains
       b22 = p5
       b3 = p6
     end if
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_velocity_2_funcs(v02_func=v02, dv02_func=dv02)

--- a/src/equilibria/smod_equil_suydam_cluster.f08
+++ b/src/equilibria/smod_equil_suydam_cluster.f08
@@ -41,7 +41,6 @@ contains
       k2 = 1.0_dp
       k3 = -1.2_dp
     end if ! LCOV_EXCL_STOP
-    call initialise_grid(settings)
 
     call background%set_density_funcs(rho0_func=rho0)
     call background%set_velocity_2_funcs(v02_func=v02)

--- a/src/equilibria/smod_equil_taylor_couette.f08
+++ b/src/equilibria/smod_equil_taylor_couette.f08
@@ -46,7 +46,6 @@ contains
       call settings%physics%enable_viscosity(viscosity_value=0.001_dp)
     end if ! LCOV_EXCL_STOP
 
-    call initialise_grid(settings)
     x_start = settings%grid%get_grid_start()
     x_end = settings%grid%get_grid_end()
 
@@ -63,7 +62,7 @@ contains
     call background%set_velocity_2_funcs(v02_func=v02, dv02_func=dv02, ddv02_func=ddv02)
     call background%set_temperature_funcs(T0_func=T0, dT0_func=dT0)
 
-    grid_middle = grid_gauss(int(settings%grid%get_gauss_gridpts() / 2))
+    grid_middle = 0.5_dp * (x_start + x_end)
     Ta = ( &
       cte_rho0 * v02(grid_middle) * h / viscosity_value &
     )**2 * 2.0_dp * h / (x_start + x_end)

--- a/src/equilibria/smod_equil_tc_pinch.f08
+++ b/src/equilibria/smod_equil_tc_pinch.f08
@@ -54,7 +54,6 @@ contains
     end if
     x_start = settings%grid%get_grid_start()
     x_end = settings%grid%get_grid_end()
-    call initialise_grid(settings)
 
     fixed_eta_value = settings%physics%resistivity%get_fixed_resistivity()
     viscosity_value = settings%physics%viscosity%get_viscosity_value()
@@ -87,7 +86,7 @@ contains
     call background%set_temperature_funcs(T0_func=T0, dT0_func=dT0)
     call background%set_magnetic_2_funcs(B02_func=B02, dB02_func=dB02, ddB02_func=ddB02)
 
-    r_mid = grid_gauss(int(settings%grid%get_gauss_gridpts() / 2))
+    r_mid = 0.5_dp * (x_start + x_end)
     Ta = ( &
       cte_rho0 * v02(r_mid) * h / viscosity_value &
     )**2 * 2.0_dp * h / (x_start + x_end)

--- a/src/equilibria/smod_user_defined.f08
+++ b/src/equilibria/smod_user_defined.f08
@@ -10,19 +10,21 @@ contains
   module procedure user_defined_eq
     call settings%grid%set_geometry("Cartesian")
     call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
-    call initialise_grid(settings)
 
     k2 = 0.0_dp
     k3 = 1.0_dp
 
     ! additional physics
     call settings%physics%enable_flow()
+    call settings%physics%enable_gravity()
 
     ! Note: functions that are not set are automatically set to zero.
     call background%set_density_funcs(rho0_func=rho0, drho0_func=drho0)
     call background%set_velocity_2_funcs(v02_func=v02, dv02_func=dv02, ddv02_func=ddv02)
     call background%set_temperature_funcs(T0_func=T0)
     call background%set_magnetic_3_funcs(B03_func=B03)
+
+    call physics%set_gravity_funcs(g0_func=g0)
   end procedure user_defined_eq
 
   real(dp) function rho0(x)
@@ -57,6 +59,13 @@ contains
     real(dp), intent(in) :: x
     B03 = x
   end function B03
+
+  real(dp) function g0(x, settings, background)
+    real(dp), intent(in) :: x
+    type(settings_t), intent(in) :: settings
+    type(background_t), intent(in) :: background
+    g0 = 1.0_dp / x**2
+  end function g0
 
   ! LCOV_EXCL_STOP
 end submodule smod_user_defined

--- a/src/main.f08
+++ b/src/main.f08
@@ -65,7 +65,7 @@ program legolas
   timer%evp_time = timer%end_timer()
 
   call timer%start_timer()
-  eigenfunctions = new_eigenfunctions(settings, background)
+  eigenfunctions = new_eigenfunctions(settings, grid, background)
   call get_eigenfunctions()
   timer%eigenfunction_time = timer%end_timer()
 

--- a/src/main.f08
+++ b/src/main.f08
@@ -18,6 +18,7 @@ program legolas
   use mod_timing, only: timer_t, new_timer
   use mod_settings, only: settings_t, new_settings
   use mod_background, only: background_t, new_background
+  use mod_grid, only: grid_t, new_grid
   use mod_eigenfunctions, only: eigenfunctions_t, new_eigenfunctions
   use mod_physics, only: physics_t, new_physics
   implicit none
@@ -45,10 +46,11 @@ program legolas
   settings = new_settings()
   background = new_background()
   physics = new_physics(settings, background)
+  grid = new_grid(settings)
 
   call timer%start_timer()
   call initialisation()
-  call set_equilibrium(settings, background, physics)
+  call set_equilibrium(settings, grid, background, physics)
   timer%init_time = timer%end_timer()
 
   call print_console_info(settings)

--- a/src/main.f08
+++ b/src/main.f08
@@ -56,7 +56,7 @@ program legolas
   call print_console_info(settings)
 
   call timer%start_timer()
-  call build_matrices(matrix_B, matrix_A, settings, background, physics)
+  call build_matrices(matrix_B, matrix_A, settings, grid, background, physics)
   timer%matrix_time = timer%end_timer()
 
   call logger%info("solving eigenvalue problem...")

--- a/src/main.f08
+++ b/src/main.f08
@@ -45,12 +45,13 @@ program legolas
 
   timer = new_timer()
   settings = new_settings()
+
+  call timer%start_timer()
+  call initialisation()
   grid = new_grid(settings)
   background = new_background()
   physics = new_physics(settings, background)
 
-  call timer%start_timer()
-  call initialisation()
   call set_equilibrium(settings, grid, background, physics)
   timer%init_time = timer%end_timer()
 

--- a/src/main.f08
+++ b/src/main.f08
@@ -31,6 +31,7 @@ program legolas
   type(timer_t) :: timer
   !> dedicated settings type
   type(settings_t) :: settings
+  type(grid_t) :: grid
   type(background_t) :: background
   type(eigenfunctions_t) :: eigenfunctions
   type(physics_t) :: physics
@@ -44,9 +45,9 @@ program legolas
 
   timer = new_timer()
   settings = new_settings()
+  grid = new_grid(settings)
   background = new_background()
   physics = new_physics(settings, background)
-  grid = new_grid(settings)
 
   call timer%start_timer()
   call initialisation()
@@ -72,6 +73,7 @@ program legolas
   call timer%start_timer()
   call create_datfile( &
     settings, &
+    grid, &
     background, &
     physics, &
     omega, &
@@ -153,16 +155,13 @@ contains
   !> Deallocates all main variables, then calls the cleanup
   !! routines of all relevant subroutines to do the same thing.
   subroutine cleanup()
-    use mod_grid, only: grid_clean
-
     call matrix_A%delete_matrix()
     call matrix_B%delete_matrix()
     deallocate(omega)
     if (allocated(right_eigenvectors)) deallocate(right_eigenvectors)
 
-    call grid_clean()
-
     call settings%delete()
+    call grid%delete()
     call background%delete()
     call physics%delete()
     call eigenfunctions%delete()

--- a/src/matrices/mod_matrix_manager.f08
+++ b/src/matrices/mod_matrix_manager.f08
@@ -1,6 +1,5 @@
 module mod_matrix_manager
   use mod_global_variables, only: dp, ir, ic
-  use mod_grid, only: grid, eps_grid, d_eps_grid_dr
   use mod_build_quadblock, only: add_to_quadblock
   use mod_equilibrium_params, only: k2, k3
   use mod_logging, only: logger, str
@@ -8,6 +7,7 @@ module mod_matrix_manager
   use mod_settings, only: settings_t
   use mod_background, only: background_t
   use mod_physics, only: physics_t
+  use mod_grid, only: grid_t
   implicit none
 
   !> quadratic basis functions
@@ -21,109 +21,109 @@ module mod_matrix_manager
 
   interface
     module subroutine add_bmatrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_bmatrix_terms
 
     module subroutine add_regular_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_regular_matrix_terms
 
     module subroutine add_flow_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_flow_matrix_terms
 
     module subroutine add_resistive_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_resistive_matrix_terms
 
     module subroutine add_cooling_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_cooling_matrix_terms
 
     module subroutine add_conduction_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_conduction_matrix_terms
 
     module subroutine add_viscosity_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_viscosity_matrix_terms
 
     module subroutine add_hall_matrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_hall_matrix_terms
 
     module subroutine add_hall_bmatrix_terms( &
-      gauss_idx, x_gauss, weight, quadblock, settings, background, physics &
+      x_gauss, weight, quadblock, settings, grid, background, physics &
     )
-      integer, intent(in) :: gauss_idx
       real(dp), intent(in) :: x_gauss
       real(dp), intent(in)  :: weight
       complex(dp), intent(inout)  :: quadblock(:, :)
       type(settings_t), intent(in) :: settings
+      type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
     end subroutine add_hall_bmatrix_terms
@@ -135,13 +135,12 @@ module mod_matrix_manager
 
 contains
 
-  subroutine build_matrices(matrix_B, matrix_A, settings, background, physics)
+  subroutine build_matrices(matrix_B, matrix_A, settings, grid, background, physics)
     use mod_global_variables, only: n_gauss, gaussian_weights
     use mod_spline_functions, only: quadratic_factors, quadratic_factors_deriv, &
       cubic_factors, cubic_factors_deriv
     use mod_matrix_structure, only: matrix_t
     use mod_boundary_manager, only: apply_boundary_conditions
-    use mod_grid, only: grid_gauss
 
     !> the B-matrix
     type(matrix_t), intent(inout) :: matrix_B
@@ -149,6 +148,7 @@ contains
     type(matrix_t), intent(inout) :: matrix_A
     !> the settings object
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
 
@@ -180,14 +180,14 @@ contains
       quadblock_B = (0.0d0, 0.0d0)
 
       ! get interval boundaries
-      x_left = grid(i)
-      x_right = grid(i + 1)
+      x_left = grid%base_grid(i)
+      x_right = grid%base_grid(i + 1)
 
       ! loop over Gaussian points to calculate integral
       do j = 1, n_gauss
         ! current grid index of Gaussian grid
         gauss_idx = (i - 1) * n_gauss + j
-        x_gauss = grid_gauss(gauss_idx)
+        x_gauss = grid%gaussian_grid(gauss_idx)
         weight = gaussian_weights(j)
 
         ! calculate spline functions for this point in the Gaussian grid
@@ -198,36 +198,36 @@ contains
 
         ! get matrix elements
         call add_bmatrix_terms( &
-          gauss_idx, x_gauss, weight, quadblock_B, settings, background, physics &
+          x_gauss, weight, quadblock_B, settings, grid, background, physics &
         )
         call add_regular_matrix_terms( &
-          gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
         if (settings%physics%flow%is_enabled()) call add_flow_matrix_terms( &
-          gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
         if (settings%physics%resistivity%is_enabled()) then
           call add_resistive_matrix_terms( &
-            gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+            x_gauss, weight, quadblock_A, settings, grid, background, physics &
           )
         end if
         if (settings%physics%cooling%is_enabled()) call add_cooling_matrix_terms( &
-          gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
         if (settings%physics%conduction%is_enabled()) then
           call add_conduction_matrix_terms( &
-            gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+            x_gauss, weight, quadblock_A, settings, grid, background, physics &
           )
         end if
         if (settings%physics%viscosity%is_enabled()) call add_viscosity_matrix_terms( &
-          gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
         if (settings%physics%hall%is_enabled()) then
           call add_hall_matrix_terms( &
-            gauss_idx, x_gauss, weight, quadblock_A, settings, background, physics &
+            x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
           call add_hall_bmatrix_terms( &
-            gauss_idx, x_gauss, weight, quadblock_B, settings, background, physics &
+            x_gauss, weight, quadblock_B, settings, grid, background, physics &
         )
         end if
       end do
@@ -255,7 +255,9 @@ contains
     end do
 
     deallocate(quadblock_A, quadblock_B)
-    call apply_boundary_conditions(matrix_A, matrix_B, settings, background, physics)
+    call apply_boundary_conditions( &
+      matrix_A, matrix_B, settings, grid, background, physics &
+    )
   end subroutine build_matrices
 
 end module mod_matrix_manager

--- a/src/matrices/smod_conduction_matrix.f08
+++ b/src/matrices/smod_conduction_matrix.f08
@@ -14,8 +14,8 @@ contains
     if (settings%physics%is_incompressible) return
 
     gamma_1 = settings%physics%get_gamma_1()
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     dT0 = background%temperature%dT0(x_gauss)
     kappa_perp = physics%conduction%tcperp(x_gauss)
     dkappa_perp_drho = physics%conduction%dtcperpdrho(x_gauss)
@@ -55,7 +55,7 @@ contains
 
     if (settings%has_bfield()) then
       call add_conduction_matrix_terms_bfield( &
-        gauss_idx, x_gauss, settings, background, physics, elements &
+        x_gauss, settings, grid, background, physics, elements &
       )
     end if
 
@@ -65,11 +65,11 @@ contains
 
 
   subroutine add_conduction_matrix_terms_bfield( &
-    gauss_idx, x_gauss, settings, background, physics, elements &
+    x_gauss, settings, grid, background, physics, elements &
   )
-    integer, intent(in) :: gauss_idx
     real(dp), intent(in) :: x_gauss
     type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
     type(matrix_elements_t), intent(inout) :: elements
@@ -86,8 +86,8 @@ contains
 
     gamma_1 = settings%physics%get_gamma_1()
     ! grid variables
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     ! temperature variables
     dT0 = background%temperature%dT0(x_gauss)
     ddT0 = background%temperature%ddT0(x_gauss)

--- a/src/matrices/smod_flow_matrix.f08
+++ b/src/matrices/smod_flow_matrix.f08
@@ -16,8 +16,8 @@ contains
 
     gamma_1 = settings%physics%get_gamma_1()
     ! grid variables
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     ! density variables
     rho = background%density%rho0(x_gauss)
     drho = background%density%drho0(x_gauss)

--- a/src/matrices/smod_hall_matrix.f08
+++ b/src/matrices/smod_hall_matrix.f08
@@ -10,8 +10,8 @@ contains
     real(dp)  :: WVop
     type(matrix_elements_t) :: elements
 
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     rho = background%density%rho0(x_gauss)
     drho = background%density%drho0(x_gauss)
     eta_H = physics%hall%hallfactor(x_gauss)
@@ -95,8 +95,8 @@ contains
     type(matrix_elements_t) :: elements
     logical :: has_viscosity
 
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
 
     v01 = background%velocity%v01(x_gauss)
     v02 = background%velocity%v02(x_gauss)

--- a/src/matrices/smod_regular_matrix.f08
+++ b/src/matrices/smod_regular_matrix.f08
@@ -8,7 +8,7 @@ contains
     real(dp)  :: rho, eps
 
     rho = background%density%rho0(x_gauss)
-    eps = eps_grid(gauss_idx)
+    eps = grid%get_eps(x_gauss)
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
     ! Quadratic * Quadratic
@@ -41,8 +41,8 @@ contains
     gamma_1 = settings%physics%get_gamma_1()
 
     ! grid variables
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     ! density variables
     rho = background%density%rho0(x_gauss)
     drho = background%density%drho0(x_gauss)

--- a/src/matrices/smod_resistive_matrix.f08
+++ b/src/matrices/smod_resistive_matrix.f08
@@ -15,8 +15,8 @@ contains
     gamma_1 = settings%physics%get_gamma_1()
 
     ! grid variables
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     ! magnetic field variables
     B02 = background%magnetic%B02(x_gauss)
     dB02 = background%magnetic%dB02(x_gauss)

--- a/src/matrices/smod_viscosity_matrix.f08
+++ b/src/matrices/smod_viscosity_matrix.f08
@@ -20,8 +20,8 @@ contains
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
     ! grid variables
-    eps = eps_grid(gauss_idx)
-    deps = d_eps_grid_dr(gauss_idx)
+    eps = grid%get_eps(x_gauss)
+    deps = grid%get_deps()
     ! viscous heating variables
     v01 = background%velocity%v01(x_gauss)
     dv01 = background%velocity%dv01(x_gauss)

--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -26,153 +26,185 @@ module mod_equilibrium
 
   !> interface to the different equilibrium submodules
   interface
-    module subroutine adiabatic_homo_eq(settings, background, physics)
+    module subroutine adiabatic_homo_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine adiabatic_homo_eq
-    module subroutine constant_current_eq(settings, background, physics)
+    module subroutine constant_current_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine constant_current_eq
-    module subroutine coronal_flux_tube_eq(settings, background, physics)
+    module subroutine coronal_flux_tube_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine coronal_flux_tube_eq
-    module subroutine discrete_alfven_eq(settings, background, physics)
+    module subroutine discrete_alfven_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine discrete_alfven_eq
-    module subroutine flow_driven_instabilities_eq(settings, background, physics)
+    module subroutine flow_driven_instabilities_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine flow_driven_instabilities_eq
-    module subroutine gold_hoyle_eq(settings, background, physics)
+    module subroutine gold_hoyle_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine gold_hoyle_eq
-    module subroutine gravito_acoustic_eq(settings, background, physics)
+    module subroutine gravito_acoustic_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine gravito_acoustic_eq
-    module subroutine gravito_mhd_eq(settings, background, physics)
+    module subroutine gravito_mhd_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine gravito_mhd_eq
-    module subroutine interchange_modes_eq(settings, background, physics)
+    module subroutine interchange_modes_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine interchange_modes_eq
-    module subroutine internal_kink_eq(settings, background, physics)
+    module subroutine internal_kink_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine internal_kink_eq
-    module subroutine isothermal_atmosphere_eq(settings, background, physics)
+    module subroutine isothermal_atmosphere_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine isothermal_atmosphere_eq
-    module subroutine KHI_eq(settings, background, physics)
+    module subroutine KHI_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine
-    module subroutine kh_cd_instability_eq(settings, background, physics)
+    module subroutine kh_cd_instability_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine kh_cd_instability_eq
-    module subroutine magnetothermal_instability_eq(settings, background, physics)
+    module subroutine magnetothermal_instability_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine magnetothermal_instability_eq
-    module subroutine MRI_accretion_eq(settings, background, physics)
+    module subroutine MRI_accretion_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine MRI_accretion_eq
-    module subroutine photospheric_flux_tube_eq(settings, background, physics)
+    module subroutine photospheric_flux_tube_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine photospheric_flux_tube_eq
-    module subroutine resistive_homo_eq(settings, background, physics)
+    module subroutine resistive_homo_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine resistive_homo_eq
-    module subroutine resistive_tearing_modes_eq(settings, background, physics)
+    module subroutine resistive_tearing_modes_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine resistive_tearing_modes_eq
-    module subroutine resistive_tearing_modes_flow_eq(settings, background, physics)
+    module subroutine resistive_tearing_modes_flow_eq( &
+      settings, grid, background, physics &
+    )
+      type(grid_t), intent(inout) :: grid
       type(settings_t), intent(inout) :: settings
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine resistive_tearing_modes_flow_eq
-    module subroutine resonant_absorption_eq(settings, background, physics)
+    module subroutine resonant_absorption_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine resonant_absorption_eq
-    module subroutine rotating_plasma_cyl_eq(settings, background, physics)
+    module subroutine rotating_plasma_cyl_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine rotating_plasma_cyl_eq
-    module subroutine RTI_eq(settings, background, physics)
+    module subroutine RTI_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine RTI_eq
-    module subroutine RTI_KHI_eq(settings, background, physics)
+    module subroutine RTI_KHI_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine RTI_KHI_eq
-    module subroutine RTI_theta_pinch_eq(settings, background, physics)
+    module subroutine RTI_theta_pinch_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine RTI_theta_pinch_eq
-    module subroutine suydam_cluster_eq(settings, background, physics)
+    module subroutine suydam_cluster_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine suydam_cluster_eq
-    module subroutine couette_flow_eq(settings, background, physics)
+    module subroutine couette_flow_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine couette_flow_eq
-    module subroutine taylor_couette_eq(settings, background, physics)
+    module subroutine taylor_couette_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine taylor_couette_eq
-    module subroutine harris_sheet_eq(settings, background, physics)
+    module subroutine harris_sheet_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine harris_sheet_eq
-    module subroutine tc_pinch_eq(settings, background, physics)
+    module subroutine tc_pinch_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine tc_pinch_eq
-    module subroutine user_defined_eq(settings, background, physics)
+    module subroutine user_defined_eq(settings, grid, background, physics)
       type(settings_t), intent(inout) :: settings
+      type(grid_t), intent(inout) :: grid
       type(background_t), intent(inout) :: background
       type(physics_t), intent(inout) :: physics
     end subroutine user_defined_eq
@@ -200,7 +232,8 @@ contains
     ! Set equilibrium submodule to use
     call set_equilibrium_pointer(settings)
     ! Call submodule
-    call set_equilibrium_values(settings, background, physics)
+    call set_equilibrium_values(settings, grid, background, physics)
+    call grid%initialise()
 
     ! Do initial checks for NaN and negative density/temperature
     call perform_NaN_and_negative_checks(settings, grid, background, physics)

--- a/src/mod_grid.f08
+++ b/src/mod_grid.f08
@@ -199,8 +199,11 @@ contains
       call logger%warning( &
         "forcing on-axis r in cylindrical geometry, may lead to spurious eigenvalues" &
       )
-    else
-      if (is_zero(grid_start)) grid_start = 0.025_dp
+    else if (is_zero(grid_start)) then
+      grid_start = 0.025_dp
+      call logger%warning( &
+        "x_start set to 0.025 to avoid singularity, avoid by setting force_r0=.true." &
+      )
     end if
     is_valid_grid_start = .true.
     call settings%grid%set_grid_boundaries(grid_start, settings%grid%get_grid_end())

--- a/src/mod_grid.f08
+++ b/src/mod_grid.f08
@@ -1,182 +1,240 @@
 ! =============================================================================
 !> Module containing all grid-related things.
 !! Contains subroutines to create the base grid, Gaussian grid and
-!! scale factors. Also handles mesh accumulation.
+!! scale factors.
 !! An integral of \(f(x)\) in \([a, b]\) can be approximated with
-!! $$ f(x) \approx 0.5(b-a)\sum_{i=1}^n\bigl[w_i f\bigl(0.5(b-a)x_i + 0.5(a+b)\bigr)\bigr] $$
+!! $$
+!! f(x) \approx 0.5(b-a)\sum_{i=1}^n\bigl[w_i f\bigl(0.5(b-a)x_i + 0.5(a+b)\bigr)\bigr] !! $$
 !! where \(w_i\) and \(x_i\) are the weights and nodes of the Gaussian quadrature.
 !! The Gaussian grid is hence set up in every interval \([a, b]\) across the
-!! four nodes \(j\) as
+!! nodes \(j\) as
 !! $$ x_i(j) = 0.5 * dx * w_i(j) + 0.5(a + b) $$
 module mod_grid
-  use mod_global_variables, only: dp
+  use mod_global_variables, only: dp, NaN
   use mod_logging, only: logger, str
   use mod_settings, only: settings_t
   implicit none
 
   private
 
-  !> array containing the base grid
-  real(dp), allocatable   :: grid(:)
-  !> array containing the Gaussian grid
-  real(dp), allocatable   :: grid_gauss(:)
-  !> array containing the scale factor epsilon
-  real(dp), allocatable   :: eps_grid(:)
-  !> array containing the derivative of the scale factor epsilon
-  real(dp), allocatable   :: d_eps_grid_dr(:)
+  type, public :: grid_t
+    real(dp), allocatable, public :: base_grid(:)
+    real(dp), allocatable, public :: gaussian_grid(:)
+    real(dp), allocatable, public :: ef_grid(:)
 
-  public :: grid
-  public :: grid_gauss
-  public :: eps_grid
-  public :: d_eps_grid_dr
+    type(settings_t), pointer, private :: settings
+    logical, private :: is_initialised
+    logical, private :: uses_custom_base_grid
 
-  public :: initialise_grid
-  public :: set_grid_gauss
-  public :: grid_clean
+  contains
+
+    procedure, private :: set_base_grid
+    procedure, private :: set_gaussian_grid
+    procedure, private :: set_ef_grid
+
+    procedure, public :: initialise
+    procedure, public :: set_custom_grid
+    procedure, public :: get_eps
+    procedure, public :: get_deps
+    procedure, public :: delete
+  end type grid_t
+
+  public :: new_grid
 
 contains
 
+  function new_grid(settings) result(grid)
+    type(settings_t), target, intent(in) :: settings
+    type(grid_t) :: grid
+    grid%settings => settings
+    grid%is_initialised = .false.
+    grid%uses_custom_base_grid = .false.
+  end function new_grid
 
-  !> General grid initialisations.
-  !! Initialises both the regular grid and the Gaussian grid.
-  !! Does calls to the mesh accumulation routines if needed,
-  !! and sets the scale factor and its derivative.
-  !! @note  In order to avoid spurious eigenvalues in cylindrical geometry,
-  !!        the default start is set at <tt> r = 0.025 </tt> instead of
-  !!        <tt> r = 0 </tt>. The latter can be explicitly enforced by
-  !!        setting <tt>force_r0</tt> to <tt>True</tt> in the parfile. @endnote
-  !! @warning   Explicitly forcing zero on-axis can give rise to spurious eigenvalues and
-  !!            all kinds of other issues (huge values, division by zero, etc). @endwarning
-  !! @warning   Throws an error if the geometry is not set. @endwarning
-  !! @warning   Throws a warning if <tt>r = 0</tt> is forced in cylindrical geometry.
-  subroutine initialise_grid(settings, custom_grid)
-    use mod_global_variables, only: dp_LIMIT
 
+  subroutine initialise(this)
+    class(grid_t), intent(inout) :: this
+
+    if (this%is_initialised) return
+    if (.not. is_valid_grid_start(this%settings)) return
+
+    if (.not. this%uses_custom_base_grid) call this%set_base_grid()
+    call this%set_gaussian_grid()
+    if (this%settings%io%write_eigenfunctions) call this%set_ef_grid()
+    this%is_initialised = .true.
+  end subroutine initialise
+
+
+  subroutine set_custom_grid(this, custom)
+    class(grid_t), intent(inout) :: this
+    real(dp), intent(in) :: custom(:)
+
+    if (.not. is_valid_custom_base_grid(this%settings, custom)) return
+    allocate(this%base_grid, source=custom)
+    this%uses_custom_base_grid = .true.
+  end subroutine set_custom_grid
+
+
+  pure subroutine set_base_grid(this)
+    class(grid_t), intent(inout) :: this
+    integer :: i, gridpts
+    real(dp) :: dx, grid_start, grid_end
+
+    gridpts = this%settings%grid%get_gridpts()
+    allocate(this%base_grid(gridpts))
+    grid_start = this%settings%grid%get_grid_start()
+    grid_end = this%settings%grid%get_grid_end()
+    ! minus one to include the end point
+    dx = (grid_end - grid_start) / (gridpts - 1)
+    do i = 1, gridpts
+      this%base_grid(i) = grid_start + (i - 1) * dx
+    end do
+  end subroutine set_base_grid
+
+
+  pure subroutine set_gaussian_grid(this)
+    use mod_global_variables, only: gaussian_nodes, n_gauss
+
+    class(grid_t), intent(inout) :: this
+    integer :: i, j, gauss_idx
+    real(dp) :: x_lo, x_hi, dx
+
+    allocate(this%gaussian_grid(this%settings%grid%get_gauss_gridpts()))
+    do i = 1, size(this%base_grid) - 1
+      x_lo = this%base_grid(i)
+      x_hi = this%base_grid(i + 1)
+      dx = x_hi - x_lo
+      do j = 1, n_gauss
+        gauss_idx = (i - 1) * n_gauss + j
+        this%gaussian_grid(gauss_idx) = ( &
+          0.5_dp * dx * gaussian_nodes(j) + 0.5_dp * (x_lo + x_hi) &
+        )
+      end do
+    end do
+  end subroutine set_gaussian_grid
+
+
+  pure subroutine set_ef_grid(this)
+    class(grid_t), intent(inout) :: this
+    integer :: idx
+
+    allocate(this%ef_grid(this%settings%grid%get_ef_gridpts()))
+    ! first gridpoint, left edge
+    this%ef_grid(1) = this%base_grid(1)
+    ! other gridpoints
+    do idx = 1, this%settings%grid%get_gridpts() - 1
+      ! position of center point in grid interval
+      this%ef_grid(2 * idx) = 0.5_dp * (this%base_grid(idx) + this%base_grid(idx + 1))
+      ! position of end point in grid interval
+      this%ef_grid(2 * idx + 1) = this%base_grid(idx + 1)
+    end do
+  end subroutine set_ef_grid
+
+
+  impure real(dp) elemental function get_eps(this, x)
+    class(grid_t), intent(in) :: this
+    real(dp), intent(in) :: x
+
+    select case(this%settings%grid%get_geometry())
+    case("Cartesian")
+      get_eps = 1.0_dp
+    case("cylindrical")
+      get_eps = x
+    case default
+      get_eps = NaN
+      call logger%error("geometry has no defined scale factor")
+    end select
+  end function get_eps
+
+
+  impure real(dp) elemental function get_deps(this)
+    class(grid_t), intent(in) :: this
+
+    select case(this%settings%grid%get_geometry())
+    case("Cartesian")
+      get_deps = 0.0_dp
+    case("cylindrical")
+      get_deps = 1.0_dp
+    case default
+      get_deps = NaN
+      call logger%error("geometry has no defined scale factor derivative")
+    end select
+  end function get_deps
+
+
+  pure subroutine delete(this)
+    class(grid_t), intent(inout) :: this
+    if (allocated(this%base_grid)) deallocate(this%base_grid)
+    if (allocated(this%gaussian_grid)) deallocate(this%gaussian_grid)
+    if (allocated(this%ef_grid)) deallocate(this%ef_grid)
+    nullify(this%settings)
+    this%is_initialised = .false.
+  end subroutine delete
+
+
+  logical function is_valid_grid_start(settings)
+    use mod_check_values, only: is_zero
     type(settings_t), intent(inout) :: settings
-    !> custom grid to use instead of the default one, optional
-    real(dp), intent(in), optional  :: custom_grid(:)
-    character(:), allocatable :: geometry
-    integer   :: i, gridpts, gauss_gridpts
-    real(dp)  :: dx, x_start, x_end
+    real(dp) :: grid_start
 
-    geometry = settings%grid%get_geometry()
-    if (geometry == "") then
-      call logger%error("geometry must be set in submodule/parfile")
+    is_valid_grid_start = .false.
+    if (settings%grid%get_geometry() /= "cylindrical") then
+      is_valid_grid_start = .true.
       return
     end if
 
+    grid_start = settings%grid%get_grid_start()
+    if (grid_start < 0.0_dp) then
+      call logger%error("x_start must be >= 0 in cylindrical geometry")
+      return
+    end if
+
+    if (settings%grid%coaxial .and. is_zero(grid_start)) then
+      call logger%error("x_start must be > 0 to introduce an inner wall boundary")
+      return
+    end if
+
+    if (settings%grid%force_r0) then
+      grid_start = 0.0_dp
+      call logger%warning( &
+        "forcing on-axis r in cylindrical geometry, may lead to spurious eigenvalues" &
+      )
+    else
+      if (is_zero(grid_start)) grid_start = 0.025_dp
+    end if
+    is_valid_grid_start = .true.
+    call settings%grid%set_grid_boundaries(grid_start, settings%grid%get_grid_end())
+  end function is_valid_grid_start
+
+
+  logical function is_valid_custom_base_grid(settings, custom_grid)
+    type(settings_t), intent(inout) :: settings
+    real(dp), intent(in) :: custom_grid(:)
+    integer :: i, gridpts
+
+    is_valid_custom_base_grid = .false.
     gridpts = settings%grid%get_gridpts()
-    gauss_gridpts = settings%grid%get_gauss_gridpts()
-    x_start = settings%grid%get_grid_start()
-    x_end = settings%grid%get_grid_end()
-
-    allocate(grid(gridpts))
-    allocate(grid_gauss(gauss_gridpts))
-    allocate(eps_grid(gauss_gridpts))
-    allocate(d_eps_grid_dr(gauss_gridpts))
-
-    grid = 0.0d0
-    grid_gauss = 0.0d0
-
-    if (present(custom_grid)) then
-      call logger%info("using a custom base grid")
-      ! check if size matches gridpoints
-      if (size(custom_grid) /= gridpts) then
+    if (size(custom_grid) /= gridpts) then
+      call logger%error( &
+        "custom grid: sizes do not match! Expected "// str(gridpts) // &
+        " points but got " // str(size(custom_grid)) &
+      )
+      return
+    end if
+    ! check monotonicity
+    do i = 1, size(custom_grid) - 1
+      if (.not. (custom_grid(i + 1) > custom_grid(i))) then
         call logger%error( &
-          "custom grid: sizes do not match! Expected "// str(gridpts) // &
-          " points but got " // str(size(custom_grid)) &
+          "custom grid: supplied array is not monotone! Got x=" // &
+          str(custom_grid(i)) // " at index " // str(i) // " and x=" // &
+          str(custom_grid(i + 1)) // " at index " // str(i + 1) &
         )
         return
       end if
-      ! check if grid is monotonous
-      do i = 1, size(custom_grid) - 1
-        if (.not. (custom_grid(i + 1) > custom_grid(i))) then
-          call logger%error( &
-            "custom grid: supplied array is not monotone! Got x=" // &
-            str(custom_grid(i)) // " at index " // str(i) // " and x=" // &
-            str(custom_grid(i + 1)) // " at index " // str(i + 1) &
-          )
-          return
-        end if
-      end do
-      grid = custom_grid
-    else
-      if (geometry == "cylindrical" .and. abs(x_start) < dp_LIMIT) then
-        if (.not. settings%grid%force_r0) then
-          x_start = 2.5d-2
-        else
-          call logger%warning( &
-            "forcing on-axis r in cylindrical geometry. This may lead to spurious &
-            &real/imaginary eigenvalues." &
-          )
-          x_start = 0.0d0
-        end if
-        call settings%grid%set_grid_boundaries(x_start, x_end)
-      end if
-
-      ! minus one here to include x_end
-      dx = (x_end - x_start) / (gridpts-1)
-      do i = 1, gridpts
-        grid(i) = x_start + (i - 1)*dx
-      end do
-    end if
-
-    call set_grid_gauss(gridpts)
-    call set_scale_factor(geometry)
-  end subroutine initialise_grid
-
-
-  !> Sets up grid_gauss, that is, the grid evaluated in the four
-  !! Gaussian points. This is done by evaluating the weights
-  !! at the four Gaussian nodes.
-  subroutine set_grid_gauss(gridpts)
-    use mod_global_variables, only: gaussian_nodes, n_gauss
-
-    integer, intent(in) :: gridpts
-    real(dp)              :: x_lo, x_hi, dx, xi(n_gauss)
-    integer               :: i, j, idx
-
-    ! evaluates the nodes in the Gaussian quadrature
-    do i = 1, gridpts - 1
-      x_lo = grid(i)
-      x_hi = grid(i + 1)
-      dx   = x_hi - x_lo
-
-      do j = 1, n_gauss
-        xi(j) = 0.5d0 * dx * gaussian_nodes(j) + 0.5d0 * (x_lo + x_hi)
-        idx   = (i - 1) * n_gauss + j
-        grid_gauss(idx) = xi(j)
-      end do
     end do
-  end subroutine set_grid_gauss
-
-
-  !> The scale factor to switch between Cartesian and cylindrical geometries
-  !! is set here, along with its derivative. For cylindrical the scale factor
-  !! is simply equal to the Gaussian grid, and its derivative is unity.
-  !! For Cartesian the scale factor is unity and its derivative is zero.
-  !! @warning   Throws an error if the geometry is not defined correctly.
-  subroutine set_scale_factor(geometry)
-    character(len=*), intent(in) :: geometry
-
-    if (geometry == 'Cartesian') then
-      eps_grid = 1.0d0
-      d_eps_grid_dr = 0.0d0
-    else if (geometry == 'cylindrical') then
-      eps_grid = grid_gauss
-      d_eps_grid_dr = 1.0d0
-    else
-      call logger%error("geometry not defined correctly: " // trim(geometry))
-    end if
-  end subroutine set_scale_factor
-
-
-  !> Cleanup routine, deallocates the arrays at module scope.
-  subroutine grid_clean()
-    deallocate(grid)
-    deallocate(grid_gauss)
-    deallocate(eps_grid)
-    deallocate(d_eps_grid_dr)
-  end subroutine grid_clean
+    ! ensure grid start/end are consistent
+    call settings%grid%set_grid_boundaries(custom_grid(1), custom_grid(gridpts))
+    is_valid_custom_base_grid = .true.
+  end function is_valid_custom_base_grid
 
 end module mod_grid

--- a/src/mod_grid.f08
+++ b/src/mod_grid.f08
@@ -56,7 +56,6 @@ contains
     class(grid_t), intent(inout) :: this
 
     if (this%is_initialised) return
-    if (.not. is_valid_grid_start(this%settings)) return
 
     if (.not. this%uses_custom_base_grid) call this%set_base_grid()
     call this%set_gaussian_grid()
@@ -170,44 +169,6 @@ contains
     nullify(this%settings)
     this%is_initialised = .false.
   end subroutine delete
-
-
-  logical function is_valid_grid_start(settings)
-    use mod_check_values, only: is_zero
-    type(settings_t), intent(inout) :: settings
-    real(dp) :: grid_start
-
-    is_valid_grid_start = .false.
-    if (settings%grid%get_geometry() /= "cylindrical") then
-      is_valid_grid_start = .true.
-      return
-    end if
-
-    grid_start = settings%grid%get_grid_start()
-    if (grid_start < 0.0_dp) then
-      call logger%error("x_start must be >= 0 in cylindrical geometry")
-      return
-    end if
-
-    if (settings%grid%coaxial .and. is_zero(grid_start)) then
-      call logger%error("x_start must be > 0 to introduce an inner wall boundary")
-      return
-    end if
-
-    if (settings%grid%force_r0) then
-      grid_start = 0.0_dp
-      call logger%warning( &
-        "forcing on-axis r in cylindrical geometry, may lead to spurious eigenvalues" &
-      )
-    else if (is_zero(grid_start)) then
-      grid_start = 0.025_dp
-      call logger%warning( &
-        "x_start set to 0.025 to avoid singularity, avoid by setting force_r0=.true." &
-      )
-    end if
-    is_valid_grid_start = .true.
-    call settings%grid%set_grid_boundaries(grid_start, settings%grid%get_grid_end())
-  end function is_valid_grid_start
 
 
   logical function is_valid_custom_base_grid(settings, custom_grid)

--- a/src/settings/mod_settings.f08
+++ b/src/settings/mod_settings.f08
@@ -51,7 +51,7 @@ module mod_settings
 
 contains
 
-  pure function new_settings() result(settings)
+  function new_settings() result(settings)
     type(settings_t) :: settings
 
     call settings%set_state_vector(physics_type="mhd")

--- a/tests/unit_tests/mod_suite_utils.f90
+++ b/tests/unit_tests/mod_suite_utils.f90
@@ -3,6 +3,7 @@ module mod_suite_utils
   use mod_settings, only: settings_t, new_settings
   use mod_background, only: background_t, new_background
   use mod_physics, only: physics_t, new_physics
+  use mod_grid, only: grid_t, new_grid
   use mod_function_utils, only: from_function
   use mod_logging, only: logger
   implicit none
@@ -50,12 +51,11 @@ contains
   end function get_physics
 
 
-  integer function get_grid_idx(x)
-    use mod_grid, only: grid_gauss
-
-    real(dp), intent(in) :: x
-    get_grid_idx = minloc(abs(grid_gauss - x), dim=1)
-  end function get_grid_idx
+  function get_grid(settings) result(grid)
+    type(settings_t), intent(in) :: settings
+    type(grid_t) :: grid
+    grid = new_grid(settings)
+  end function get_grid
 
 
   real(dp) function zero(x)
@@ -70,22 +70,12 @@ contains
   end function one
 
 
-  subroutine clean_up(settings)
-    use mod_grid, only: grid, grid_clean
-
-    type(settings_t), intent(in) :: settings
-
-    if (allocated(grid)) call grid_clean()
-  end subroutine clean_up
-
-
-  subroutine create_test_grid(settings, pts, geometry, grid_start, grid_end)
-    use mod_grid, only: initialise_grid
-
+  function create_test_grid(settings, pts, geometry, grid_start, grid_end) result(grid)
     type(settings_t), intent(inout) :: settings
     integer, intent(in), optional :: pts
     character(len=*), intent(in), optional :: geometry
     real(dp), intent(in), optional  :: grid_start, grid_end
+    type(grid_t) :: grid
     real(dp) :: x_start, x_end
     integer :: gridpts
     character(:), allocatable :: grid_geometry
@@ -114,8 +104,10 @@ contains
     call settings%grid%set_grid_boundaries(x_start, x_end)
     call settings%grid%set_gridpts(gridpts)
     call settings%update_block_dimensions()
-    call initialise_grid(settings)
-  end subroutine create_test_grid
+
+    grid = new_grid(settings)
+    call grid%initialise()
+  end function create_test_grid
 
 
   subroutine set_default_units(settings)

--- a/tests/unit_tests/mod_test_boundaries.pf
+++ b/tests/unit_tests/mod_test_boundaries.pf
@@ -4,7 +4,6 @@ module mod_test_boundaries
   use mod_boundary_manager, only: apply_boundary_conditions
   use mod_matrix_structure, only: matrix_t, new_matrix
   use mod_transform_matrix, only: matrix_to_array, array_to_matrix
-  use mod_grid, only: grid_clean
   implicit none
 
   integer, parameter :: points = 160
@@ -21,6 +20,7 @@ module mod_test_boundaries
   type(settings_t) :: settings
   type(background_t) :: background
   type(physics_t) :: physics
+  type(grid_t) :: grid
 
 contains
 
@@ -30,7 +30,7 @@ contains
     settings = get_settings()
     background = get_background()
     physics = get_physics(settings, background)
-    call create_test_grid(settings, pts=10, geometry="Cartesian")
+    call set_cartesian_grid()
     ! avoid division by B0 for MHD in boundaries if conduction is enabled
     call background%set_magnetic_3_funcs(B03_func=one)
 
@@ -42,12 +42,12 @@ contains
 
   @after
   subroutine teardown_test()
-    call grid_clean()
     call amat%delete_matrix()
     call bmat%delete_matrix()
     call settings%delete()
     call background%delete()
     call physics%delete()
+    call grid%delete()
   end subroutine teardown_test
 
 
@@ -80,6 +80,17 @@ contains
   end subroutine zero_out_expected_left_idxs
 
 
+  subroutine set_cartesian_grid()
+    call grid%delete()
+    grid = create_test_grid(settings, pts=10, geometry="Cartesian")
+  end subroutine set_cartesian_grid
+
+  subroutine set_cylindrical_grid()
+    call grid%delete()
+    grid = create_test_grid(settings, pts=10, geometry="cylindrical")
+  end subroutine set_cylindrical_grid
+
+
   subroutine zero_out_expected_right_idxs(idxs)
     integer, intent(in) :: idxs(:)
     integer :: i, j
@@ -99,9 +110,8 @@ contains
   @test
   subroutine test_regular_boundaries_wall_bmat()
     call set_name("regular boundary conditions (B-matrix, wall)")
-
     ! boundary conditions on odd v1, a2, a3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     ! set expected
     call zero_out_expected_left_idxs([3, 13, 15])
@@ -114,7 +124,7 @@ contains
   subroutine test_regular_boundaries_wall_amat()
     call set_name("regular boundary conditions (A-matrix, wall)")
     ! boundary conditions on odd v1, a2, a3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     call zero_out_expected_left_idxs([3, 13, 15])
     call zero_out_expected_right_idxs([147, 157, 159])
@@ -127,7 +137,7 @@ contains
     call set_name("conduction boundary conditions (B-matrix, wall, no k_perp)")
     call settings%physics%enable_parallel_conduction()
     ! boundary conditions on odd v1, a2, a3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     call zero_out_expected_left_idxs([3, 13, 15])
     call zero_out_expected_right_idxs([147, 157, 159])
@@ -141,7 +151,7 @@ contains
     call set_name("conduction boundary conditions (A-matrix, wall, no k_perp)")
     call settings%physics%enable_parallel_conduction()
     ! boundary conditions on odd v1, a2, a3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     call zero_out_expected_left_idxs([3, 13, 15])
     call zero_out_expected_right_idxs([147, 157, 159])
@@ -155,7 +165,7 @@ contains
     call set_name("conduction boundary conditions (B-matrix, wall, k_perp)")
     call settings%physics%enable_perpendicular_conduction(fixed_tc_perp_value=1.0_dp)
     ! boundary conditions on odd v1, a2, a3, even T1
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     call zero_out_expected_left_idxs([3, 10, 13, 15])
     call zero_out_expected_right_idxs([147, 154, 157, 159])
@@ -169,7 +179,7 @@ contains
     call set_name("conduction boundary conditions (A-matrix, wall, k_perp)")
     call settings%physics%enable_perpendicular_conduction(fixed_tc_perp_value=1.0_dp)
     ! boundary conditions on odd v1, a2, a3, even T1
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     call zero_out_expected_left_idxs([3, 10, 13, 15])
     call zero_out_expected_right_idxs([147, 154, 157, 159])
@@ -184,7 +194,7 @@ contains
     ! zero viscosity value to prevent natural boundaries from being applied
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
     ! boundary conditions on odd v1, a2, a3, even v2, v3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     call zero_out_expected_left_idxs([3, 6, 8, 13, 15])
     call zero_out_expected_right_idxs([147, 150, 152, 157, 159])
@@ -198,7 +208,7 @@ contains
     call set_name("viscous boundary conditions (A-matrix, wall)")
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
     ! boundary conditions on odd v1, a2, a3, even v2, v3
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     call zero_out_expected_left_idxs([3, 6, 8, 13, 15])
     call zero_out_expected_right_idxs([147, 150, 152, 157, 159])
@@ -210,11 +220,9 @@ contains
   @test
   subroutine test_viscous_boundaries_cylindrical_wall_bmat()
     call set_name("viscous boundary conditions (B-matrix, wall, cylindrical)")
-    ! reset the grid to cylindrical
-    call grid_clean()
-    call create_test_grid(settings, pts=10, geometry="cylindrical")
+    call set_cylindrical_grid()
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     ! no additional left side boundary conditions
     call zero_out_expected_left_idxs([3, 13, 15])
@@ -228,11 +236,9 @@ contains
   @test
   subroutine test_viscous_boundaries_cylindrical_wall_amat()
     call set_name("viscous boundary conditions (A-matrix, wall, cylindrical)")
-    ! reset the grid to cylindrical
-    call grid_clean()
-    call create_test_grid(settings, pts=10, geometry="cylindrical")
+    call set_cylindrical_grid()
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     ! no additional left side boundary conditions
     call zero_out_expected_left_idxs([3, 13, 15])
@@ -246,12 +252,10 @@ contains
   @test
   subroutine test_viscous_boundaries_cylindrical_coax_wall_bmat()
     call set_name("viscous boundary conditions (B-matrix, wall, coaxial)")
-    ! reset the grid to cylindrical
-    call grid_clean()
-    call create_test_grid(settings, pts=10, geometry="cylindrical")
+    call set_cylindrical_grid()
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
     settings%grid%coaxial = .true.
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=bmat, array=bmat_array)
     call zero_out_expected_left_idxs([3, 6, 8, 13, 15])
     ! boundary conditions on odd v1, a2, a3, even v2, v3
@@ -264,12 +268,10 @@ contains
   @test
   subroutine test_viscous_boundaries_cylindrical_coax_wall_amat()
     call set_name("viscous boundary conditions (A-matrix, wall, coaxial)")
-    ! reset the grid to cylindrical
-    call grid_clean()
-    call create_test_grid(settings, pts=10, geometry="cylindrical")
+    call set_cylindrical_grid()
     call settings%physics%enable_viscosity(viscosity_value=0.0_dp)
     settings%grid%coaxial = .true.
-    call apply_boundary_conditions(amat, bmat, settings, background, physics)
+    call apply_boundary_conditions(amat, bmat, settings, grid, background, physics)
     call matrix_to_array(matrix=amat, array=amat_array)
     call zero_out_expected_left_idxs([3, 6, 8, 13, 15])
     ! boundary conditions on odd v1, a2, a3, even v2, v3

--- a/tests/unit_tests/mod_test_cooling.pf
+++ b/tests/unit_tests/mod_test_cooling.pf
@@ -50,7 +50,6 @@ contains
 
   @after
   subroutine teardown_test()
-    call clean_up(settings)
     call settings%delete()
     call physics%delete()
     T0values = 0.0_dp

--- a/tests/unit_tests/mod_test_eigenfunctions.pf
+++ b/tests/unit_tests/mod_test_eigenfunctions.pf
@@ -8,6 +8,7 @@ module mod_test_eigenfunctions
   complex(dp), allocatable :: eigenvectors(:, :)
   type(settings_t) :: settings
   type(background_t) :: background
+  type(grid_t) :: grid
   type(eigenfunctions_t) :: eigenfunctions
 
 contains
@@ -58,8 +59,8 @@ contains
     call reset_globals()
     settings = get_settings()
     background = get_background()
-    eigenfunctions = new_eigenfunctions(settings, background)
-    call create_test_grid(settings, pts=20, geometry="Cartesian")
+    grid = create_test_grid(settings, pts=20, geometry="Cartesian")
+    eigenfunctions = new_eigenfunctions(settings, grid, background)
     ! creates a square grid between (-2, 2) and (2, -2)
     pos = 1
     do i = 2, -2, -1
@@ -73,9 +74,9 @@ contains
 
   @after
   subroutine teardown_test()
-    call clean_up(settings)
     call eigenfunctions%delete()
     call settings%delete()
+    call grid%delete()
     if (allocated(eigenvectors)) deallocate(eigenvectors)
   end subroutine teardown_test
 

--- a/tests/unit_tests/mod_test_grid.pf
+++ b/tests/unit_tests/mod_test_grid.pf
@@ -1,11 +1,11 @@
 module mod_test_grid
   use mod_suite_utils
   use funit
-  use mod_grid, only: grid, initialise_grid
   implicit none
 
   integer :: i
   type(settings_t) :: settings
+  type(grid_t) :: grid
 
 contains
 
@@ -19,19 +19,19 @@ contains
 
   @after
   subroutine teardown_test()
-    call clean_up(settings)
     call settings%delete()
+    call grid%delete()
   end subroutine teardown_test
 
 
   @test
   subroutine test_cartesian_grid()
     call set_name("cartesian grid")
-    call create_test_grid(settings, 51, "Cartesian", 1.0d0, 3.0d0)
-    @assertEqual(1.0d0, grid(1), tolerance=TOL)
-    @assertEqual(3.0d0, grid(51), tolerance=TOL)
+    grid = create_test_grid(settings, 51, "Cartesian", 1.0d0, 3.0d0)
+    @assertEqual(1.0d0, grid%base_grid(1), tolerance=TOL)
+    @assertEqual(3.0d0, grid%base_grid(51), tolerance=TOL)
     do i = 1, 50
-      @assertLessThan(grid(i), grid(i + 1))
+      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
     end do
   end subroutine test_cartesian_grid
 
@@ -39,11 +39,11 @@ contains
   @test
   subroutine test_cylindrical_grid()
     call set_name("cylindrical grid")
-    call create_test_grid(settings, 31, "cylindrical", 0.0d0, 1.0d0)
-    @assertGreaterThan(grid(1), 2.0d-2)
-    @assertEqual(1.0d0, grid(31), tolerance=TOL)
+    grid = create_test_grid(settings, 31, "cylindrical", 0.0d0, 1.0d0)
+    @assertGreaterThan(grid%base_grid(1), 2.0d-2)
+    @assertEqual(1.0d0, grid%base_grid(31), tolerance=TOL)
     do i = 1, 30
-      @assertLessThan(grid(i), grid(i + 1))
+      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
     end do
   end subroutine test_cylindrical_grid
 
@@ -53,43 +53,23 @@ contains
     call set_name("cylindrical grid, force r=0")
     settings%grid%force_r0 = .true.
     call logger%set_logging_level(0)
-    call create_test_grid(settings, 31, "cylindrical", 0.0d0, 2.0d0)
-    @assertEqual(0.0d0, grid(1), tolerance=TOL)
-    @assertEqual(2.0d0, grid(31), tolerance=TOL)
+    grid = create_test_grid(settings, 31, "cylindrical", 0.0d0, 2.0d0)
+    @assertEqual(0.0d0, grid%base_grid(1), tolerance=TOL)
+    @assertEqual(2.0d0, grid%base_grid(31), tolerance=TOL)
     do i = 1, 30
-      @assertLessThan(grid(i), grid(i + 1))
+      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
     end do
   end subroutine test_cylindrical_grid_force_r0
 
 
   @test
   subroutine test_grid_gauss_monotonicity()
-    use mod_grid, only: grid_gauss
-
     call set_name("monotonicity grid_gauss")
-    call create_test_grid(settings, 31, "Cartesian")
+    grid = create_test_grid(settings, 31, "Cartesian")
     do i = 1, settings%grid%get_gauss_gridpts() - 1
-      @assertLessThan(grid_gauss(i), grid_gauss(i + 1))
+      @assertLessThan(grid%gaussian_grid(i), grid%gaussian_grid(i + 1))
     end do
   end subroutine test_grid_gauss_monotonicity
-
-
-  @test
-  subroutine test_grid_no_geometry_set()
-    call set_name("setting grid without geometry")
-    call settings%grid%set_geometry("")
-    call initialise_grid(settings)
-    @assertExceptionRaised("geometry must be set in submodule/parfile")
-  end subroutine test_grid_no_geometry_set
-
-
-  @test
-  subroutine test_grid_wrong_geometry_set()
-    call set_name("setting grid with unknown geometry")
-    call settings%grid%set_geometry("unknown")
-    call initialise_grid(settings)
-    @assertExceptionRaised("geometry not defined correctly: unknown")
-  end subroutine test_grid_wrong_geometry_set
 
 
   @test
@@ -98,11 +78,12 @@ contains
 
     call set_name("setting custom grid")
     call settings%grid%set_gridpts(50)
-    call settings%grid%set_geometry("Cartesian")
     custom_grid = linspace(x0=0.0d0, x1=3.0d0, xvals=50)
-    call initialise_grid(settings, custom_grid=custom_grid)
-    @assertEqual(0.0d0, grid(1), tolerance=TOL)
-    @assertEqual(3.0d0, grid(50), tolerance=TOL)
+    grid = new_grid(settings)
+    call grid%set_custom_grid(custom_grid)
+    call grid%initialise()
+    @assertEqual(0.0d0, grid%base_grid(1), tolerance=TOL)
+    @assertEqual(3.0d0, grid%base_grid(50), tolerance=TOL)
   end subroutine test_custom_grid
 
 
@@ -113,8 +94,9 @@ contains
 
     call set_name("setting custom grid, wrong size")
     call settings%grid%set_gridpts(100)
-    call settings%grid%set_geometry("Cartesian")
-    call initialise_grid(settings, custom_grid=custom_grid)
+    grid = new_grid(settings)
+    call grid%set_custom_grid(custom_grid)
+    call grid%initialise()
     error_msg = "custom grid: sizes do not match! Expected 100 points but got 50"
     @assertExceptionRaised(trim(error_msg))
   end subroutine test_custom_grid_wrong_size
@@ -127,10 +109,11 @@ contains
 
     call set_name("setting custom grid, not monotone")
     call settings%grid%set_gridpts(50)
-    call settings%grid%set_geometry("Cartesian")
     custom_grid = linspace(x0=0.0d0, x1=2.0d0, xvals=50)
     custom_grid(15) = 1.2d0
-    call initialise_grid(settings, custom_grid=custom_grid)
+    grid = new_grid(settings)
+    call grid%set_custom_grid(custom_grid)
+    call grid%initialise()
     error_msg = ( &
       "custom grid: supplied array is not monotone! &
       &Got x=1.20000000 at index 15 and x=0.61224490 at index 16" &
@@ -141,23 +124,19 @@ contains
 
   @test
   subroutine test_scale_factor_Cartesian()
-    use mod_grid, only: eps_grid, d_eps_grid_dr
-
     call set_name("scale factor Cartesian")
-    call create_test_grid(settings, 51, "Cartesian", 0.0d0, 2.0d0)
-    @assertEqual(1.0d0, eps_grid, tolerance=TOL)
-    @assertEqual(0.0d0, d_eps_grid_dr, tolerance=TOL)
+    grid = create_test_grid(settings, 51, "Cartesian", 0.0d0, 2.0d0)
+    @assertEqual(1.0d0, grid%get_eps(grid%gaussian_grid), tolerance=TOL)
+    @assertEqual(0.0d0, grid%get_deps(), tolerance=TOL)
   end subroutine test_scale_factor_Cartesian
 
 
   @test
   subroutine test_scale_factor_cylindrical()
-    use mod_grid, only: grid_gauss, eps_grid, d_eps_grid_dr
-
     call set_name("scale factor cylindrical")
-    call create_test_grid(settings, 51, "cylindrical", 0.0d0, 2.0d0)
-    @assertEqual(grid_gauss, eps_grid, tolerance=TOL)
-    @assertEqual(1.0d0, d_eps_grid_dr, tolerance=TOL)
+    grid = create_test_grid(settings, 51, "cylindrical", 0.0d0, 2.0d0)
+    @assertEqual(grid%gaussian_grid, grid%get_eps(grid%gaussian_grid), tolerance=TOL)
+    @assertEqual(1.0d0, grid%get_deps(), tolerance=TOL)
   end subroutine test_scale_factor_cylindrical
 
 end module mod_test_grid

--- a/tests/unit_tests/mod_test_inspections.pf
+++ b/tests/unit_tests/mod_test_inspections.pf
@@ -9,6 +9,7 @@ module mod_test_inspections
   type(settings_t) :: settings
   type(background_t) :: background
   type(physics_t) :: physics
+  type(grid_t) :: grid
 
 contains
 
@@ -18,16 +19,16 @@ contains
     settings = get_settings()
     background = get_background()
     physics = get_physics(settings, background)
-    call create_test_grid(settings)
+    grid = create_test_grid(settings)
   end subroutine init_test
 
 
   @after
   subroutine teardown_test()
-    call clean_up(settings)
     call settings%delete()
     call background%delete()
     call physics%delete()
+    call grid%delete()
   end subroutine teardown_test
 
 
@@ -49,7 +50,7 @@ contains
 
   subroutine do_checks()
     use mod_inspections, only: perform_NaN_and_negative_checks
-    call perform_NaN_and_negative_checks(settings, background, physics)
+    call perform_NaN_and_negative_checks(settings, grid, background, physics)
   end subroutine do_checks
 
 

--- a/tests/unit_tests/mod_test_solar_atmosphere.pf
+++ b/tests/unit_tests/mod_test_solar_atmosphere.pf
@@ -6,6 +6,7 @@ module mod_test_solar_atmosphere
 
   type(settings_t) :: settings
   type(background_t) :: background
+  type(grid_t) :: grid
   type(physics_t) :: physics
 
 contains
@@ -15,19 +16,19 @@ contains
     settings = get_settings()
     background = new_background()
     physics = new_physics(settings, background)
-    call set_default_units(settings)
-    call create_test_grid( &
+    grid = create_test_grid( &
       settings, geometry="Cartesian", grid_start=0.05d0, grid_end=0.35d0 &
     )
+    call set_default_units(settings)
   end subroutine init_test
 
 
   @after
   subroutine tear_down()
-    call clean_up(settings)
     call settings%delete()
     call background%delete()
     call physics%delete()
+    call grid%delete()
     call solar_atmosphere_dealloc()
   end subroutine tear_down
 
@@ -46,7 +47,7 @@ contains
     use mod_inspections, only: perform_NaN_and_negative_checks
     call set_name("solar atmosphere (NaNs and negative values)")
     call set_solar_atmosphere(settings, background, physics)
-    call perform_NaN_and_negative_checks(settings, background, physics)
+    call perform_NaN_and_negative_checks(settings, grid, background, physics)
   end subroutine test_sa_neg_and_nans
 
 end module mod_test_solar_atmosphere

--- a/tests/unit_tests/mod_test_units.pf
+++ b/tests/unit_tests/mod_test_units.pf
@@ -20,7 +20,6 @@ contains
 
   @after
   subroutine teardown_test()
-    call clean_up(settings)
     call settings%delete()
   end subroutine teardown_test
 


### PR DESCRIPTION
## PR description
Last in the line of refactoring PR's (after #126 and #127), this deprecates the global grid variables in `mod_grid` in favour of a dedicated grid object, created in the main program and passed along to the respective functions. This is done in preparation of grid accumulation support. 
Note that this PR **changes the Legolas API in the user submodule**.
Changes implied by this PR:

- Users no longer need to initialise the grid in the user submodule, but have access to the grid object to set for example a custom grid
- Everything is now contained within a dedicated object, reducing module interlinks and dependencies.

## New features
**Legolas**
- A new `grid` object to govern the various grids
