### PR TITLE
Support for user-defined grid accumulation

### DIFF
--- a/src/mod_grid.f08
+++ b/src/mod_grid.f08
@@ -17,23 +17,34 @@ module mod_grid
 
   private
 
+  interface
+    real(dp) function dx_func_i(x)
+      use mod_global_variables, only: dp
+      real(dp), intent(in) :: x
+    end function dx_func_i
+  end interface
+
   type, public :: grid_t
     real(dp), allocatable, public :: base_grid(:)
     real(dp), allocatable, public :: gaussian_grid(:)
     real(dp), allocatable, public :: ef_grid(:)
+    procedure(dx_func_i), pointer, nopass, private :: dx_func => null()
 
     type(settings_t), pointer, private :: settings
     logical, private :: is_initialised
     logical, private :: uses_custom_base_grid
+    logical, private :: uses_custom_dx
 
   contains
 
     procedure, private :: set_base_grid
     procedure, private :: set_gaussian_grid
     procedure, private :: set_ef_grid
+    procedure, private :: generate_grid
 
     procedure, public :: initialise
     procedure, public :: set_custom_grid
+    procedure, public :: set_spacing_function
     procedure, public :: get_eps
     procedure, public :: get_deps
     procedure, public :: delete
@@ -49,6 +60,7 @@ contains
     grid%settings => settings
     grid%is_initialised = .false.
     grid%uses_custom_base_grid = .false.
+    grid%uses_custom_dx = .false.
   end function new_grid
 
 
@@ -74,20 +86,35 @@ contains
   end subroutine set_custom_grid
 
 
-  pure subroutine set_base_grid(this)
+  subroutine set_spacing_function(this, dx_func)
     class(grid_t), intent(inout) :: this
-    integer :: i, gridpts
-    real(dp) :: dx, grid_start, grid_end
+    procedure(dx_func_i) :: dx_func
 
-    gridpts = this%settings%grid%get_gridpts()
-    allocate(this%base_grid(gridpts))
+    this%dx_func => dx_func
+    this%uses_custom_dx = .true.
+    call logger%info("grid generation: using custom grid spacing function")
+  end subroutine set_spacing_function
+
+
+  subroutine set_base_grid(this)
+    class(grid_t), intent(inout) :: this
+    integer :: gridpts
+    real(dp) :: grid_start, grid_end
+
     grid_start = this%settings%grid%get_grid_start()
     grid_end = this%settings%grid%get_grid_end()
-    ! minus one to include the end point
-    dx = (grid_end - grid_start) / (gridpts - 1)
-    do i = 1, gridpts
-      this%base_grid(i) = grid_start + (i - 1) * dx
-    end do
+    gridpts = this%settings%grid%get_gridpts()
+
+    if (.not. associated(this%dx_func)) this%dx_func => constant_dx
+    call this%generate_grid()
+
+    contains
+
+    real(dp) function constant_dx(x)
+      real(dp), intent(in) :: x
+      ! minus one to include the end point
+      constant_dx = (grid_end - grid_start) / (gridpts - 1)
+    end function constant_dx
   end subroutine set_base_grid
 
 
@@ -130,6 +157,37 @@ contains
   end subroutine set_ef_grid
 
 
+  subroutine generate_grid(this)
+    class(grid_t), intent(inout) :: this
+    real(dp) :: kappa, grid_start, grid_end
+    real(dp), allocatable :: xbar(:)
+    integer :: i, pts
+
+    if (this%uses_custom_dx) then
+      pts = get_updated_number_of_gridpoints(this%settings, this%dx_func)
+      call this%settings%grid%set_gridpts(pts)
+    else
+      pts = this%settings%grid%get_gridpts()
+    end if
+
+    grid_start = this%settings%grid%get_grid_start()
+    grid_end = this%settings%grid%get_grid_end()
+    allocate(xbar(pts))
+    xbar(1) = grid_start
+    do i = 2, pts
+      xbar(i) = xbar(i - 1) + this%dx_func(xbar(i - 1))
+    end do
+    kappa = (grid_end - xbar(pts - 1)) / (xbar(pts) - xbar(pts - 1))
+
+    allocate(this%base_grid(pts))
+    this%base_grid(1) = grid_start
+    do i = 1, pts - 1
+      this%base_grid(i + 1) = xbar(i) + kappa * this%dx_func(xbar(i))
+    end do
+    deallocate(xbar)
+  end subroutine generate_grid
+
+
   impure real(dp) elemental function get_eps(this, x)
     class(grid_t), intent(in) :: this
     real(dp), intent(in) :: x
@@ -167,6 +225,7 @@ contains
     if (allocated(this%gaussian_grid)) deallocate(this%gaussian_grid)
     if (allocated(this%ef_grid)) deallocate(this%ef_grid)
     nullify(this%settings)
+    nullify(this%dx_func)
     this%is_initialised = .false.
   end subroutine delete
 
@@ -200,5 +259,49 @@ contains
     call settings%grid%set_grid_boundaries(custom_grid(1), custom_grid(gridpts))
     is_valid_custom_base_grid = .true.
   end function is_valid_custom_base_grid
+
+
+  function get_updated_number_of_gridpoints(settings, dx_func) result(updated_pts)
+    type(settings_t), intent(in) :: settings
+    procedure(dx_func_i) :: dx_func
+    integer :: gridpts, updated_pts
+    real(dp) :: dx, xbar, grid_start, grid_end
+
+    grid_start = settings%grid%get_grid_start()
+    grid_end = settings%grid%get_grid_end()
+    gridpts = settings%grid%get_gridpts()
+    ! first pass to get updated number of gridpoints (no change for constant dx)
+    xbar = grid_start
+    updated_pts = 1
+    do while (xbar < grid_end)
+      dx = dx_func(xbar)
+      if (.not. is_valid_dx(dx)) return
+      xbar = xbar + dx
+      updated_pts = updated_pts + 1
+    end do
+    call log_msg_by_gridpoint_change(old_pts=gridpts, new_pts=updated_pts)
+  end function get_updated_number_of_gridpoints
+
+
+  logical function is_valid_dx(dx)
+    real(dp), intent(in) :: dx
+    is_valid_dx = .true.
+    if (dx <= 0.0_dp) then
+      is_valid_dx = .false.
+      call logger%error("dx must be positive, got dx = " // str(dx))
+    end if
+  end function is_valid_dx
+
+
+  subroutine log_msg_by_gridpoint_change(old_pts, new_pts)
+    integer, intent(in) :: old_pts
+    integer, intent(in) :: new_pts
+
+    if (old_pts == new_pts) return
+    call logger%info( &
+      "grid generation: number of gridpoints changed from " // &
+      str(old_pts) // " to " // str(new_pts) // " to accomodate specified dx." &
+    )
+  end subroutine log_msg_by_gridpoint_change
 
 end module mod_grid

--- a/src/settings/mod_grid_settings.f08
+++ b/src/settings/mod_grid_settings.f08
@@ -131,7 +131,7 @@ contains
       )
     else if (is_zero(this%grid_start)) then
       this%grid_start = 0.025_dp
-      call logger%warning( &
+      call logger%info( &
         "grid start set to 0.025 to avoid on-axis singularity. " // &
         "Set 'force_r0 = .true.' to force r=0. " &
       )

--- a/tests/unit_tests/mod_test_grid.pf
+++ b/tests/unit_tests/mod_test_grid.pf
@@ -14,6 +14,9 @@ contains
   subroutine init_test()
     call reset_globals()
     settings = new_settings()
+    call settings%grid%set_geometry("Cartesian")
+    call settings%grid%set_gridpts(50)
+    call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
   end subroutine init_test
 
 
@@ -24,51 +27,55 @@ contains
   end subroutine teardown_test
 
 
+  logical function is_monotonic(array)
+    real(dp), intent(in) :: array(:)
+    is_monotonic = .true.
+    do i = 1, size(array) - 1
+      if (array(i) > array(i + 1)) then
+        is_monotonic = .false.
+        exit
+      end if
+    end do
+  end function is_monotonic
+
+
   @test
   subroutine test_cartesian_grid()
-    call set_name("cartesian grid")
+    call set_name("grid: cartesian")
     grid = create_test_grid(settings, 51, "Cartesian", 1.0d0, 3.0d0)
     @assertEqual(1.0d0, grid%base_grid(1), tolerance=TOL)
     @assertEqual(3.0d0, grid%base_grid(51), tolerance=TOL)
-    do i = 1, 50
-      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
-    end do
+    @assertTrue(is_monotonic(grid%base_grid))
   end subroutine test_cartesian_grid
 
 
   @test
   subroutine test_cylindrical_grid()
-    call set_name("cylindrical grid")
+    call set_name("grid: cylindrical")
     grid = create_test_grid(settings, 31, "cylindrical", 0.0d0, 1.0d0)
     @assertGreaterThan(grid%base_grid(1), 2.0d-2)
     @assertEqual(1.0d0, grid%base_grid(31), tolerance=TOL)
-    do i = 1, 30
-      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
-    end do
+    @assertTrue(is_monotonic(grid%base_grid))
   end subroutine test_cylindrical_grid
 
 
   @test
   subroutine test_cylindrical_grid_force_r0()
-    call set_name("cylindrical grid, force r=0")
+    call set_name("grid: cylindrical, force r=0")
     settings%grid%force_r0 = .true.
     call logger%set_logging_level(0)
     grid = create_test_grid(settings, 31, "cylindrical", 0.0d0, 2.0d0)
     @assertEqual(0.0d0, grid%base_grid(1), tolerance=TOL)
     @assertEqual(2.0d0, grid%base_grid(31), tolerance=TOL)
-    do i = 1, 30
-      @assertLessThan(grid%base_grid(i), grid%base_grid(i + 1))
-    end do
+    @assertTrue(is_monotonic(grid%base_grid))
   end subroutine test_cylindrical_grid_force_r0
 
 
   @test
   subroutine test_grid_gauss_monotonicity()
-    call set_name("monotonicity grid_gauss")
+    call set_name("grid: monotonicity Gaussian grid")
     grid = create_test_grid(settings, 31, "Cartesian")
-    do i = 1, settings%grid%get_gauss_gridpts() - 1
-      @assertLessThan(grid%gaussian_grid(i), grid%gaussian_grid(i + 1))
-    end do
+    @assertTrue(is_monotonic(grid%gaussian_grid))
   end subroutine test_grid_gauss_monotonicity
 
 
@@ -76,7 +83,7 @@ contains
   subroutine test_custom_grid()
     real(dp)  :: custom_grid(50)
 
-    call set_name("setting custom grid")
+    call set_name("grid: setting custom grid")
     call settings%grid%set_gridpts(50)
     custom_grid = linspace(x0=0.0d0, x1=3.0d0, xvals=50)
     grid = new_grid(settings)
@@ -92,7 +99,7 @@ contains
     real(dp)  :: custom_grid(50)
     character(len=125) :: error_msg
 
-    call set_name("setting custom grid, wrong size")
+    call set_name("grid: setting custom grid, wrong size")
     call settings%grid%set_gridpts(100)
     grid = new_grid(settings)
     call grid%set_custom_grid(custom_grid)
@@ -107,7 +114,7 @@ contains
     real(dp)  :: custom_grid(50)
     character(len=125) :: error_msg
 
-    call set_name("setting custom grid, not monotone")
+    call set_name("grid: setting custom grid, not monotone")
     call settings%grid%set_gridpts(50)
     custom_grid = linspace(x0=0.0d0, x1=2.0d0, xvals=50)
     custom_grid(15) = 1.2d0
@@ -124,7 +131,7 @@ contains
 
   @test
   subroutine test_scale_factor_Cartesian()
-    call set_name("scale factor Cartesian")
+    call set_name("grid: scale factor Cartesian")
     grid = create_test_grid(settings, 51, "Cartesian", 0.0d0, 2.0d0)
     @assertEqual(1.0d0, grid%get_eps(grid%gaussian_grid), tolerance=TOL)
     @assertEqual(0.0d0, grid%get_deps(), tolerance=TOL)
@@ -133,10 +140,108 @@ contains
 
   @test
   subroutine test_scale_factor_cylindrical()
-    call set_name("scale factor cylindrical")
+    call set_name("grid: scale factor cylindrical")
     grid = create_test_grid(settings, 51, "cylindrical", 0.0d0, 2.0d0)
     @assertEqual(grid%gaussian_grid, grid%get_eps(grid%gaussian_grid), tolerance=TOL)
     @assertEqual(1.0d0, grid%get_deps(), tolerance=TOL)
   end subroutine test_scale_factor_cylindrical
+
+
+  @test
+  subroutine test_spacing_function_default()
+    integer, parameter :: pts = 100
+    real(dp) :: dx_expected, dx_actual
+    call set_name("grid: default spacing function")
+    call settings%grid%set_grid_boundaries(-1.0_dp, 1.0_dp)
+    call settings%grid%set_gridpts(pts)
+    grid = new_grid(settings)
+    call grid%initialise()
+
+    dx_expected = 2.0_dp / (pts - 1)
+    do i = 1, pts - 1
+      dx_actual = grid%base_grid(i + 1) - grid%base_grid(i)
+      @assertEqual(dx_expected, dx_actual, tolerance=TOL)
+    end do
+    @assertTrue(is_monotonic(grid%base_grid))
+  end subroutine test_spacing_function_default
+
+
+  @test
+  subroutine test_spacing_function_custom_constant()
+    integer, parameter :: pts = 100
+    integer :: gridpts
+    real(dp) :: dx_expected, dx_actual
+    call set_name("grid: custom spacing function, constant")
+    call settings%grid%set_grid_boundaries(-1.0_dp, 2.0_dp)
+    call settings%grid%set_gridpts(pts)
+    grid = new_grid(settings)
+    call grid%set_spacing_function(dx)
+    call grid%initialise()
+    gridpts = settings%grid%get_gridpts()
+
+    @assertEqual(-1.0_dp, grid%base_grid(1))
+    @assertEqual(2.0_dp, grid%base_grid(gridpts))
+    dx_expected = dx(1.0_dp)
+    do i = 2, gridpts - 1
+      dx_actual = grid%base_grid(i + 1) - grid%base_grid(i)
+      @assertEqual(dx_expected, dx_actual, tolerance=TOL)
+    end do
+    @assertTrue(is_monotonic(grid%base_grid))
+
+  contains
+
+    real(dp) function dx(x)
+      real(dp), intent(in) :: x
+      dx = 3.0_dp / (2 * pts - 1)
+    end function dx
+  end subroutine test_spacing_function_custom_constant
+
+
+  @test
+  subroutine test_spacing_function_custom_exponential()
+    integer, parameter :: pts = 100
+    integer :: gridpts
+    call set_name("grid: custom spacing function, exponential")
+    call settings%grid%set_grid_boundaries(-2.0_dp, 2.0_dp)
+    call settings%grid%set_gridpts(pts)
+    grid = new_grid(settings)
+    call grid%set_spacing_function(exponential_dx)
+    call grid%initialise()
+    gridpts = settings%grid%get_gridpts()
+
+    @assertEqual(-2.0_dp, grid%base_grid(1))
+    @assertEqual(2.0_dp, grid%base_grid(gridpts))
+    @assertTrue(is_monotonic(grid%base_grid))
+
+  contains
+
+    real(dp) function exponential_dx(x)
+      real(dp), intent(in) :: x
+      exponential_dx = 1.0_dp / (exp(2.0_dp * x) + 5.0_dp)
+    end function exponential_dx
+  end subroutine test_spacing_function_custom_exponential
+
+
+  @test
+  subroutine test_spacing_function_custom_negative_dx()
+    call set_name("grid: custom spacing function, negative dx")
+    call settings%grid%set_grid_boundaries(-1.0_dp, 1.0_dp)
+    call settings%grid%set_gridpts(100)
+    grid = new_grid(settings)
+    call grid%set_spacing_function(negative_dx)
+    call grid%initialise()
+    @assertExceptionRaised("dx must be positive, got dx = -0.10000000")
+
+  contains
+
+    real(dp) function negative_dx(x)
+      real(dp), intent(in) :: x
+      if (x < 0.5_dp) then
+        negative_dx = 0.1_dp
+      else
+        negative_dx = -0.1_dp
+      end if
+    end function negative_dx
+  end subroutine test_spacing_function_custom_negative_dx
 
 end module mod_test_grid


### PR DESCRIPTION
## PR description
This PR adds a minor change to the existing grid structure, allowing the user to specify a spacing function to calculate `dx` when setting up the grid. If nothing is specified a constant grid spacing is used, based on the grid start/end points and the number of gridpoints provided.

Note that the number of gridpoints may vary whenever a custom grid spacing function is supplied, this change will be logged in the terminal and automatically propagated throughout the code using the `settings%grid` object instance.

Example usage in the user submodule, for the case of a Gaussian profile:
```fortran 
module procedure user_defined_eq

  call settings%grid%set_grid_boundaries(-1.0_dp, 2.0_dp)
  call grid%set_spacing_function(gaussian_dx)

end procedure user_defined_eq

real(dp) function gaussian_dx(x)
  real(dp), intent(in) :: x
  real(dp) :: base, low, center, width
  base = 0.15_dp
  low = 0.01_dp
  center = 0.5_dp
  width = 0.2_dp
  gaussian_dx = base - (base - low) * exp(-(x - center)**2 / (2.0_dp * width))
end function gaussian_dx
```

which looks like this:
<img width="581" src="https://user-images.githubusercontent.com/43474374/228887219-ec0c1919-6068-4c31-90fe-a3c149d89491.png">

The total number of gridpoints in this case decreases from 100 to 61.


## New features
**Legolas**
- Support for user-defined grid accumulation
