### PR TITLE
Split heating and cooling terms

### DIFF
--- a/post_processing/pylbo/automation/defaults.py
+++ b/post_processing/pylbo/automation/defaults.py
@@ -37,6 +37,7 @@ namelist_items = {
         ("flow", bool),
         ("radiative_cooling", bool),
         ("heating", bool),
+        ("force_thermal_balance", bool),
         ("ncool", (int, np.integer)),
         ("cooling_curve", str),
         ("external_gravity", bool),

--- a/post_processing/pylbo/visualisation/profiles.py
+++ b/post_processing/pylbo/visualisation/profiles.py
@@ -38,6 +38,8 @@ class EquilibriumProfile(InteractiveFigureWindow):
             name = name.replace("0", "_0")
         name = name.replace("01", "_{01}").replace("02", "_{02}").replace("03", "_{03}")
         name = name.replace("_para", "_{\\parallel}").replace("_perp", "_{\\perp}")
+        name = name.replace("lambdaT", r"{\Lambda(T)}")
+        name = name.replace("dlambdadT", r"d{\Lambda(T)}dT")
         if "dL" in name:
             name = name.replace("dL", r"d\mathcal{L}")
         return f"${name}$"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set (sources
         physics/mod_atmosphere_curves.f08
         physics/mod_solar_atmosphere.f08
         physics/mod_radiative_cooling.f08
+        physics/mod_heatloss.f08
         physics/mod_thermal_conduction.f08
         physics/mod_hall.f08
         mod_inspections.f08
@@ -108,7 +109,7 @@ set (sources
         matrices/smod_regular_matrix.f08
         matrices/smod_flow_matrix.f08
         matrices/smod_resistive_matrix.f08
-        matrices/smod_cooling_matrix.f08
+        matrices/smod_heatloss_matrix.f08
         matrices/smod_conduction_matrix.f08
         matrices/smod_viscosity_matrix.f08
         matrices/smod_hall_matrix.f08

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set (sources
         physics/mod_atmosphere_curves.f08
         physics/mod_solar_atmosphere.f08
         physics/mod_radiative_cooling.f08
+        physics/mod_heating.f08
         physics/mod_heatloss.f08
         physics/mod_thermal_conduction.f08
         physics/mod_hall.f08

--- a/src/dataIO/mod_console.f08
+++ b/src/dataIO/mod_console.f08
@@ -158,6 +158,10 @@ contains
       logical :: heating
       heating = settings%physics%heating%is_enabled()
       call logger%info("heating                  : " // str(heating))
+      if (.not. heating) return
+      call logger%info("  forcing thermal balance: " // &
+        str(settings%physics%heating%force_thermal_balance) &
+      )
     end subroutine log_heating_info
 
     subroutine log_parallel_conduction_info()

--- a/src/dataIO/mod_console.f08
+++ b/src/dataIO/mod_console.f08
@@ -123,6 +123,7 @@ contains
     call log_flow_info()
     call log_gravity_info()
     call log_cooling_info()
+    call log_heating_info()
     call log_parallel_conduction_info()
     call log_perpendicular_conduction_info()
     call log_resistivity_info()
@@ -152,6 +153,12 @@ contains
         trim(adjustl(settings%physics%cooling%get_cooling_curve())) &
       )
     end subroutine log_cooling_info
+
+    subroutine log_heating_info()
+      logical :: heating
+      heating = settings%physics%heating%is_enabled()
+      call logger%info("heating                  : " // str(heating))
+    end subroutine log_heating_info
 
     subroutine log_parallel_conduction_info()
       logical :: tc_para

--- a/src/dataIO/mod_input.f08
+++ b/src/dataIO/mod_input.f08
@@ -188,7 +188,8 @@ contains
     character(str_len) :: iomsg
 
     character(len=str_len) :: physics_type
-    logical :: flow, incompressible, radiative_cooling, heating, external_gravity, &
+    logical :: flow, incompressible, radiative_cooling, heating, &
+      force_thermal_balance, external_gravity, &
       parallel_conduction, perpendicular_conduction, resistivity, use_eta_dropoff, &
       viscosity, viscous_heating, hall_mhd, hall_dropoff, &
       elec_inertia, inertia_dropoff
@@ -201,7 +202,8 @@ contains
     real(dp) :: dropoff_edge_dist, dropoff_width
 
     namelist /physicslist/ &
-      physics_type, mhd_gamma, flow, incompressible, radiative_cooling, heating, &
+      physics_type, mhd_gamma, flow, incompressible, radiative_cooling, &
+      heating, force_thermal_balance, &
       external_gravity, parallel_conduction, perpendicular_conduction, &
       resistivity, use_eta_dropoff, viscosity, viscous_heating, hall_mhd, &
       hall_dropoff, elec_inertia, inertia_dropoff, ncool, &
@@ -220,6 +222,7 @@ contains
 
     radiative_cooling = settings%physics%cooling%is_enabled()
     heating = settings%physics%heating%is_enabled()
+    force_thermal_balance = settings%physics%heating%force_thermal_balance
     ncool = settings%physics%cooling%get_interpolation_points()
     cooling_curve = settings%physics%cooling%get_cooling_curve()
 
@@ -254,7 +257,7 @@ contains
     if (incompressible) call settings%physics%set_incompressible()
     if (flow) call settings%physics%flow%enable()
     if (radiative_cooling) call settings%physics%enable_cooling(cooling_curve, ncool)
-    if (heating) call settings%physics%enable_heating()
+    if (heating) call settings%physics%enable_heating(force_thermal_balance)
     if (external_gravity) call settings%physics%enable_gravity()
     if (parallel_conduction) then
       call settings%physics%enable_parallel_conduction(fixed_tc_para_value)

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -363,9 +363,9 @@ contains
     write(dat_fh) from_function(background%velocity%ddv02, grid%gaussian_grid)
     write(dat_fh) from_function(background%velocity%ddv03, grid%gaussian_grid)
 
-    write(dat_fh) from_function(physics%cooling%L0, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%cooling%dLdT, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%cooling%dLdrho, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%L0, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%dLdT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%dLdrho, grid%gaussian_grid)
     write(dat_fh) from_function(physics%conduction%tcpara, grid%gaussian_grid)
     write(dat_fh) from_function(physics%conduction%tcperp, grid%gaussian_grid)
     write(dat_fh) from_function(physics%resistivity%eta, grid%gaussian_grid)

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -312,7 +312,7 @@ contains
 
 
   subroutine write_equilibrium_names()
-    integer, parameter :: nb_names = 36
+    integer, parameter :: nb_names = 38
     character(len=str_len_arr) :: equilibrium_names(nb_names)
 
     equilibrium_names = [ &
@@ -322,6 +322,7 @@ contains
       "B01", "B02", "B03", "dB02", "db03", "ddB02", "ddb03", "B0", &
       "v01", "v02", "v03", "dv01", "dv02", "dv03", "ddv01", "ddv02", "ddv03", &
       "L0", "dLdT", "dLdrho", &
+      "lambdaT", "dlambdadT", &
       "H0", "dHdT", "dHdrho", &
       "kappa_para", "kappa_perp", &
       "eta", "detadT", "detadr", &
@@ -364,12 +365,14 @@ contains
     write(dat_fh) from_function(background%velocity%ddv02, grid%gaussian_grid)
     write(dat_fh) from_function(background%velocity%ddv03, grid%gaussian_grid)
 
-    write(dat_fh) from_function(physics%heatloss%L0, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%heatloss%dLdT, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%heatloss%dLdrho, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%heating%H, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%heating%dHdT, grid%gaussian_grid)
-    write(dat_fh) from_function(physics%heating%dHdrho, grid%gaussian_grid)
+    write(dat_fh) physics%heatloss%get_L0(grid%gaussian_grid)
+    write(dat_fh) physics%heatloss%get_dLdT(grid%gaussian_grid)
+    write(dat_fh) physics%heatloss%get_dLdrho(grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%cooling%lambdaT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%cooling%dlambdadT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%heating%H, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%heating%dHdT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heatloss%heating%dHdrho, grid%gaussian_grid)
 
     write(dat_fh) from_function(physics%conduction%tcpara, grid%gaussian_grid)
     write(dat_fh) from_function(physics%conduction%tcperp, grid%gaussian_grid)

--- a/src/dataIO/mod_output.f08
+++ b/src/dataIO/mod_output.f08
@@ -312,7 +312,7 @@ contains
 
 
   subroutine write_equilibrium_names()
-    integer, parameter :: nb_names = 33
+    integer, parameter :: nb_names = 36
     character(len=str_len_arr) :: equilibrium_names(nb_names)
 
     equilibrium_names = [ &
@@ -322,6 +322,7 @@ contains
       "B01", "B02", "B03", "dB02", "db03", "ddB02", "ddb03", "B0", &
       "v01", "v02", "v03", "dv01", "dv02", "dv03", "ddv01", "ddv02", "ddv03", &
       "L0", "dLdT", "dLdrho", &
+      "H0", "dHdT", "dHdrho", &
       "kappa_para", "kappa_perp", &
       "eta", "detadT", "detadr", &
       "gravity", &
@@ -366,6 +367,10 @@ contains
     write(dat_fh) from_function(physics%heatloss%L0, grid%gaussian_grid)
     write(dat_fh) from_function(physics%heatloss%dLdT, grid%gaussian_grid)
     write(dat_fh) from_function(physics%heatloss%dLdrho, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heating%H, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heating%dHdT, grid%gaussian_grid)
+    write(dat_fh) from_function(physics%heating%dHdrho, grid%gaussian_grid)
+
     write(dat_fh) from_function(physics%conduction%tcpara, grid%gaussian_grid)
     write(dat_fh) from_function(physics%conduction%tcperp, grid%gaussian_grid)
     write(dat_fh) from_function(physics%resistivity%eta, grid%gaussian_grid)

--- a/src/equilibria/smod_equil_discrete_alfven.f08
+++ b/src/equilibria/smod_equil_discrete_alfven.f08
@@ -37,6 +37,7 @@ contains
       call settings%grid%set_geometry("cylindrical")
       call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
       call settings%physics%enable_cooling(cooling_curve="rosner")
+      call settings%physics%enable_heating(force_thermal_balance=.true.)
       call settings%physics%enable_parallel_conduction()
       call settings%units%set_units_from_density( &
         unit_density=1.5e-15_dp, &

--- a/src/equilibria/smod_equil_gold_hoyle.f08
+++ b/src/equilibria/smod_equil_gold_hoyle.f08
@@ -45,6 +45,7 @@ contains
       call settings%grid%set_geometry("cylindrical")
       call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
       call settings%physics%enable_cooling(cooling_curve="rosner")
+      call settings%physics%enable_heating(force_thermal_balance=.true.)
       call settings%physics%enable_parallel_conduction()
 
       k2 = 1.0_dp

--- a/src/equilibria/smod_equil_magnetothermal_instabilities.f08
+++ b/src/equilibria/smod_equil_magnetothermal_instabilities.f08
@@ -36,6 +36,7 @@ contains
       call settings%grid%set_geometry("cylindrical")
       call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
       call settings%physics%enable_cooling(cooling_curve="rosner")
+      call settings%physics%enable_heating(force_thermal_balance=.true.)
       call settings%physics%enable_parallel_conduction()
       call settings%units%set_units_from_temperature( &
         unit_temperature=2.6e6_dp, &

--- a/src/matrices/mod_matrix_manager.f08
+++ b/src/matrices/mod_matrix_manager.f08
@@ -68,7 +68,7 @@ module mod_matrix_manager
       type(physics_t), intent(in) :: physics
     end subroutine add_resistive_matrix_terms
 
-    module subroutine add_cooling_matrix_terms( &
+    module subroutine add_heatloss_matrix_terms( &
       x_gauss, weight, quadblock, settings, grid, background, physics &
     )
       real(dp), intent(in) :: x_gauss
@@ -78,7 +78,7 @@ module mod_matrix_manager
       type(grid_t), intent(in) :: grid
       type(background_t), intent(in) :: background
       type(physics_t), intent(in) :: physics
-    end subroutine add_cooling_matrix_terms
+    end subroutine add_heatloss_matrix_terms
 
     module subroutine add_conduction_matrix_terms( &
       x_gauss, weight, quadblock, settings, grid, background, physics &
@@ -211,7 +211,7 @@ contains
             x_gauss, weight, quadblock_A, settings, grid, background, physics &
           )
         end if
-        if (settings%physics%cooling%is_enabled()) call add_cooling_matrix_terms( &
+        if (settings%physics%cooling%is_enabled()) call add_heatloss_matrix_terms( &
           x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
         if (settings%physics%conduction%is_enabled()) then

--- a/src/matrices/smod_heatloss_matrix.f08
+++ b/src/matrices/smod_heatloss_matrix.f08
@@ -13,9 +13,9 @@ contains
 
     gamma_1 = settings%physics%get_gamma_1()
     rho = background%density%rho0(x_gauss)
-    Lrho = physics%heatloss%dLdrho(x_gauss)
-    LT = physics%heatloss%dLdT(x_gauss)
-    L0 = physics%heatloss%L0(x_gauss)
+    Lrho = physics%heatloss%get_dLdrho(x_gauss)
+    LT = physics%heatloss%get_dLdT(x_gauss)
+    L0 = physics%heatloss%get_L0(x_gauss)
 
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 

--- a/src/matrices/smod_heatloss_matrix.f08
+++ b/src/matrices/smod_heatloss_matrix.f08
@@ -1,9 +1,9 @@
-submodule (mod_matrix_manager) smod_cooling_matrix
+submodule (mod_matrix_manager) smod_heatloss_matrix
   implicit none
 
 contains
 
-  module procedure add_cooling_matrix_terms
+  module procedure add_heatloss_matrix_terms
     real(dp) :: rho
     real(dp) :: Lrho, LT, L0
     real(dp) :: gamma_1
@@ -13,9 +13,9 @@ contains
 
     gamma_1 = settings%physics%get_gamma_1()
     rho = background%density%rho0(x_gauss)
-    Lrho = physics%cooling%dLdrho(x_gauss)
-    LT = physics%cooling%dLdT(x_gauss)
-    L0 = physics%cooling%L0(x_gauss)
+    Lrho = physics%heatloss%dLdrho(x_gauss)
+    LT = physics%heatloss%dLdT(x_gauss)
+    L0 = physics%heatloss%L0(x_gauss)
 
     elements = new_matrix_elements(state_vector=settings%get_state_vector())
 
@@ -24,6 +24,6 @@ contains
 
     call add_to_quadblock(quadblock, elements, weight, settings%dims)
     call elements%delete()
-  end procedure add_cooling_matrix_terms
+  end procedure add_heatloss_matrix_terms
 
-end submodule smod_cooling_matrix
+end submodule smod_heatloss_matrix

--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -239,7 +239,7 @@ contains
     call perform_NaN_and_negative_checks(settings, grid, background, physics)
 
     if (settings%physics%cooling%is_enabled()) then
-      call physics%cooling%initialise()
+      call physics%heatloss%cooling%initialise()
     end if
     call physics%heatloss%check_if_thermal_balance_needs_enforcing( &
       physics%conduction, grid &

--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -241,6 +241,9 @@ contains
     if (settings%physics%cooling%is_enabled()) then
       call physics%cooling%initialise()
     end if
+    call physics%heatloss%check_if_thermal_balance_needs_enforcing( &
+      physics%conduction, grid &
+    )
     call physics%hall%validate_scale_ratio(grid%gaussian_grid)
 
     ! Do final sanity checks on values

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -324,7 +324,7 @@ contains
       dkappa_perp_dr = physics%conduction%dtcperpdr(x)
       Kp = physics%conduction%tcprefactor(x)
       dKp = physics%conduction%dtcprefactordr(x)
-      L0 = physics%heatloss%L0(x)
+      L0 = physics%heatloss%get_L0(x)
 
       eq_cond = ( &
         T0 * rho0 * (deps * v01 + eps * dv01) / eps &

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -324,7 +324,7 @@ contains
       dkappa_perp_dr = physics%conduction%dtcperpdr(x)
       Kp = physics%conduction%tcprefactor(x)
       dKp = physics%conduction%dtcprefactordr(x)
-      L0 = physics%cooling%L0(x)
+      L0 = physics%heatloss%L0(x)
 
       eq_cond = ( &
         T0 * rho0 * (deps * v01 + eps * dv01) / eps &

--- a/src/physics/mod_heating.f08
+++ b/src/physics/mod_heating.f08
@@ -1,0 +1,50 @@
+module mod_heating
+  use mod_global_variables, only: dp
+  use mod_settings, only: settings_t
+  use mod_background, only: background_t
+  use mod_function_utils, only: zero_func
+  implicit none
+
+  private
+
+  type(settings_t), pointer :: settings => null()
+  type(background_t), pointer :: background => null()
+
+  type, public :: heating_t
+    procedure(real(dp)), pointer, nopass :: H
+    procedure(real(dp)), pointer, nopass :: dH
+    procedure(real(dp)), pointer, nopass :: dHdT
+    procedure(real(dp)), pointer, nopass :: dHdrho
+
+  contains
+    procedure, public :: delete
+  end type heating_t
+
+  public :: new_heating
+
+contains
+
+  function new_heating(settings_tgt, background_tgt) result(heating)
+    type(settings_t), target, intent(in) :: settings_tgt
+    type(background_t), target, intent(in) :: background_tgt
+    type(heating_t) :: heating
+    settings => settings_tgt
+    background => background_tgt
+
+    heating%H => zero_func
+    heating%dH => zero_func
+    heating%dHdT => zero_func
+    heating%dHdrho => zero_func
+  end function new_heating
+
+  subroutine delete(this)
+    class(heating_t), intent(inout) :: this
+    nullify(settings)
+    nullify(background)
+    nullify(this%H)
+    nullify(this%dH)
+    nullify(this%dHdT)
+    nullify(this%dHdrho)
+  end subroutine delete
+
+end module mod_heating

--- a/src/physics/mod_heating.f08
+++ b/src/physics/mod_heating.f08
@@ -12,7 +12,6 @@ module mod_heating
 
   type, public :: heating_t
     procedure(real(dp)), pointer, nopass :: H
-    procedure(real(dp)), pointer, nopass :: dH
     procedure(real(dp)), pointer, nopass :: dHdT
     procedure(real(dp)), pointer, nopass :: dHdrho
 
@@ -32,7 +31,6 @@ contains
     background => background_tgt
 
     heating%H => zero_func
-    heating%dH => zero_func
     heating%dHdT => zero_func
     heating%dHdrho => zero_func
   end function new_heating
@@ -42,7 +40,6 @@ contains
     nullify(settings)
     nullify(background)
     nullify(this%H)
-    nullify(this%dH)
     nullify(this%dHdT)
     nullify(this%dHdrho)
   end subroutine delete

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -1,0 +1,70 @@
+module mod_heatloss
+  use mod_global_variables, only: dp
+  use mod_settings, only: settings_t
+  use mod_background, only: background_t
+  use mod_radiative_cooling, only: cooling_t
+  implicit none
+  private
+
+  type(settings_t), pointer :: settings => null()
+  type(background_t), pointer :: background => null()
+  type(cooling_t), pointer :: cooling =>  null()
+
+  type, public :: heatloss_t
+    procedure(real(dp)), pointer, nopass :: L0
+    procedure(real(dp)), pointer, nopass :: dLdT
+    procedure(real(dp)), pointer, nopass :: dLdrho
+
+  contains
+    procedure, public :: delete
+  end type heatloss_t
+
+  public :: new_heatloss
+
+contains
+
+  function new_heatloss(settings_tgt, background_tgt, cooling_tgt) result(heatloss)
+    type(settings_t), target, intent(in) :: settings_tgt
+    type(background_t), target, intent(in) :: background_tgt
+    type(cooling_t), target, intent(in) :: cooling_tgt
+    type(heatloss_t) :: heatloss
+
+    settings => settings_tgt
+    background => background_tgt
+    cooling => cooling_tgt
+
+    heatloss%L0 => get_L0
+    heatloss%dLdT => get_dLdT
+    heatloss%dLdrho => get_dLdrho
+  end function new_heatloss
+
+
+  real(dp) function get_L0(x)
+    real(dp), intent(in) :: x
+    get_L0 = 0.0_dp
+  end function get_L0
+
+
+  real(dp) function get_dLdT(x)
+    real(dp), intent(in) :: x
+    get_dLdT = background%density%rho0(x) * cooling%dlambdadT(x)
+  end function get_dLdT
+
+
+  real(dp) function get_dLdrho(x)
+    real(dp), intent(in) :: x
+    get_dLdrho = cooling%lambdaT(x)
+  end function get_dLdrho
+
+
+  subroutine delete(this)
+    class(heatloss_t), intent(inout) :: this
+    nullify(settings)
+    nullify(background)
+    nullify(cooling)
+    nullify(this%L0)
+    nullify(this%dLdT)
+    nullify(this%dLdrho)
+  end subroutine delete
+
+end module mod_heatloss

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -1,9 +1,12 @@
 module mod_heatloss
   use mod_global_variables, only: dp
+  use mod_logging, only: logger
   use mod_settings, only: settings_t
   use mod_background, only: background_t
   use mod_radiative_cooling, only: cooling_t
   use mod_heating, only: heating_t
+  use mod_thermal_conduction, only: conduction_t
+  use mod_grid, only: grid_t
   implicit none
   private
 
@@ -11,6 +14,8 @@ module mod_heatloss
   type(background_t), pointer :: background => null()
   type(cooling_t), pointer :: cooling =>  null()
   type(heating_t), pointer :: heating => null()
+  type(conduction_t), pointer :: conduction => null()
+  type(grid_t), pointer :: grid => null()
 
   type, public :: heatloss_t
     procedure(real(dp)), pointer, nopass :: L0
@@ -18,6 +23,7 @@ module mod_heatloss
     procedure(real(dp)), pointer, nopass :: dLdrho
 
   contains
+    procedure, public :: check_if_thermal_balance_needs_enforcing
     procedure, public :: delete
   end type heatloss_t
 
@@ -63,12 +69,64 @@ contains
   end function get_dLdrho
 
 
+  subroutine check_if_thermal_balance_needs_enforcing(this, conduction_tgt, grid_tgt)
+    class(heatloss_t), intent(inout) :: this
+    type(conduction_t), target, intent(in) :: conduction_tgt
+    type(grid_t), target, intent(in) :: grid_tgt
+
+    if (.not. settings%physics%heating%is_enabled()) return
+    if (.not. settings%physics%heating%force_thermal_balance) return
+
+    ! needed for eps and deps + physics in function below
+    grid => grid_tgt
+    conduction => conduction_tgt
+
+    call logger%info("enforcing thermal balance by setting a constant heating term")
+    heating%H => H_for_thermal_balance
+  end subroutine check_if_thermal_balance_needs_enforcing
+
+
+  real(dp) function H_for_thermal_balance(x)
+    real(dp), intent(in) :: x
+    real(dp) :: rho0, T0, dT0, ddT0, v01, dv01, B01
+    real(dp) :: eps, deps
+    real(dp) :: Kp, dKp, tcperp, dtcperpdr
+
+    rho0 = background%density%rho0(x)
+    T0 = background%temperature%T0(x)
+    dT0 = background%temperature%dT0(x)
+    ddT0 = background%temperature%ddT0(x)
+    v01 = background%velocity%v01(x)
+    dv01 = background%velocity%dv01(x)
+    B01 = background%magnetic%B01(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
+    Kp = conduction%tcprefactor(x)
+    dKp = conduction%dtcprefactordr(x)
+    tcperp = conduction%tcperp(x)
+    dtcperpdr = conduction%dtcperpdr(x)
+
+    H_for_thermal_balance = rho0 * cooling%lambdaT(x) + (1.0_dp / rho0) * ( &
+      T0 * rho0 * (deps * v01 + eps * dv01) / eps &
+      - B01**2 * (dKp * dT0 + Kp * ddT0) &
+      - (1.0_dp / eps) * ( &
+          deps * tcperp * dT0 &
+          + eps * dtcperpdr * dT0 &
+          + eps * tcperp * ddT0 &
+        ) &
+      + (1.0_dp / settings%physics%get_gamma_1()) * dT0 * rho0 * v01 &
+    )
+  end function H_for_thermal_balance
+
+
   subroutine delete(this)
     class(heatloss_t), intent(inout) :: this
     nullify(settings)
     nullify(background)
     nullify(cooling)
     nullify(heating)
+    nullify(grid)
+    nullify(conduction)
     nullify(this%L0)
     nullify(this%dLdT)
     nullify(this%dLdrho)

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -3,12 +3,14 @@ module mod_heatloss
   use mod_settings, only: settings_t
   use mod_background, only: background_t
   use mod_radiative_cooling, only: cooling_t
+  use mod_heating, only: heating_t
   implicit none
   private
 
   type(settings_t), pointer :: settings => null()
   type(background_t), pointer :: background => null()
   type(cooling_t), pointer :: cooling =>  null()
+  type(heating_t), pointer :: heating => null()
 
   type, public :: heatloss_t
     procedure(real(dp)), pointer, nopass :: L0
@@ -23,15 +25,19 @@ module mod_heatloss
 
 contains
 
-  function new_heatloss(settings_tgt, background_tgt, cooling_tgt) result(heatloss)
+  function new_heatloss( &
+    settings_tgt, background_tgt, cooling_tgt, heating_tgt &
+  ) result(heatloss)
     type(settings_t), target, intent(in) :: settings_tgt
     type(background_t), target, intent(in) :: background_tgt
     type(cooling_t), target, intent(in) :: cooling_tgt
+    type(heating_t), target, intent(in) :: heating_tgt
     type(heatloss_t) :: heatloss
 
     settings => settings_tgt
     background => background_tgt
     cooling => cooling_tgt
+    heating => heating_tgt
 
     heatloss%L0 => get_L0
     heatloss%dLdT => get_dLdT
@@ -62,6 +68,7 @@ contains
     nullify(settings)
     nullify(background)
     nullify(cooling)
+    nullify(heating)
     nullify(this%L0)
     nullify(this%dLdT)
     nullify(this%dLdrho)

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -47,19 +47,19 @@ contains
 
   real(dp) function get_L0(x)
     real(dp), intent(in) :: x
-    get_L0 = 0.0_dp
+    get_L0 = background%density%rho0(x) * cooling%lambdaT(x) - heating%H(x)
   end function get_L0
 
 
   real(dp) function get_dLdT(x)
     real(dp), intent(in) :: x
-    get_dLdT = background%density%rho0(x) * cooling%dlambdadT(x)
+    get_dLdT = background%density%rho0(x) * cooling%dlambdadT(x) - heating%dHdT(x)
   end function get_dLdT
 
 
   real(dp) function get_dLdrho(x)
     real(dp), intent(in) :: x
-    get_dLdrho = cooling%lambdaT(x)
+    get_dLdrho = cooling%lambdaT(x) - heating%dHdrho(x)
   end function get_dLdrho
 
 

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -7,6 +7,7 @@ module mod_physics
   use mod_hall, only: hall_t, new_hall
   use mod_thermal_conduction, only: conduction_t, new_conduction
   use mod_radiative_cooling, only: cooling_t, new_cooling
+  use mod_heatloss, only: heatloss_t, new_heatloss
   implicit none
 
   private
@@ -17,7 +18,8 @@ module mod_physics
     type(hall_t) :: hall
     type(conduction_t) :: conduction
     type(cooling_t) :: cooling
-  contains
+    type(heatloss_t) :: heatloss
+    contains
     procedure, public :: set_resistivity_funcs
     procedure, public :: set_gravity_funcs
     procedure, public :: set_parallel_conduction_funcs
@@ -39,6 +41,7 @@ contains
     physics%hall = new_hall(settings, background)
     physics%conduction = new_conduction(settings, background)
     physics%cooling = new_cooling(settings, background)
+    physics%heatloss = new_heatloss(settings, background, physics%cooling)
   end function new_physics
 
 
@@ -105,6 +108,7 @@ contains
     call this%hall%delete()
     call this%conduction%delete()
     call this%cooling%delete()
+    call this%heatloss%delete
   end subroutine delete
 
 end module mod_physics

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -7,6 +7,7 @@ module mod_physics
   use mod_hall, only: hall_t, new_hall
   use mod_thermal_conduction, only: conduction_t, new_conduction
   use mod_radiative_cooling, only: cooling_t, new_cooling
+  use mod_heating, only: heating_t, new_heating
   use mod_heatloss, only: heatloss_t, new_heatloss
   implicit none
 
@@ -18,6 +19,7 @@ module mod_physics
     type(hall_t) :: hall
     type(conduction_t) :: conduction
     type(cooling_t) :: cooling
+    type(heating_t) :: heating
     type(heatloss_t) :: heatloss
     contains
     procedure, public :: set_resistivity_funcs
@@ -41,7 +43,10 @@ contains
     physics%hall = new_hall(settings, background)
     physics%conduction = new_conduction(settings, background)
     physics%cooling = new_cooling(settings, background)
-    physics%heatloss = new_heatloss(settings, background, physics%cooling)
+    physics%heating = new_heating(settings, background)
+    physics%heatloss = new_heatloss( &
+      settings, background, physics%cooling, physics%heating &
+    )
   end function new_physics
 
 
@@ -108,6 +113,7 @@ contains
     call this%hall%delete()
     call this%conduction%delete()
     call this%cooling%delete()
+    call this%heating%delete()
     call this%heatloss%delete
   end subroutine delete
 

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -21,11 +21,13 @@ module mod_physics
     type(cooling_t) :: cooling
     type(heating_t) :: heating
     type(heatloss_t) :: heatloss
-    contains
+  contains
     procedure, public :: set_resistivity_funcs
     procedure, public :: set_gravity_funcs
     procedure, public :: set_parallel_conduction_funcs
     procedure, public :: set_perpendicular_conduction_funcs
+    procedure, public :: set_cooling_funcs
+    procedure, public :: set_heating_funcs
     procedure, public :: delete
   end type physics_t
 
@@ -104,6 +106,28 @@ contains
     if (present(dtcperpdB2_func)) this%conduction%dtcperpdB2 => dtcperpdB2_func
     if (present(dtcperpdr_func)) this%conduction%dtcperpdr => dtcperpdr_func
   end subroutine set_perpendicular_conduction_funcs
+
+
+  subroutine set_cooling_funcs(this, lambdaT_func, dlambdadT_func)
+    class(physics_t), intent(inout) :: this
+    procedure(real(dp)) :: lambdaT_func
+    procedure(real(dp)), optional :: dlambdadT_func
+
+    this%cooling%lambdaT => lambdaT_func
+    if (present(dlambdadT_func)) this%cooling%dlambdadT => dlambdadT_func
+  end subroutine set_cooling_funcs
+
+
+  subroutine set_heating_funcs(this, H_func, dHdT_func, dHdrho_func)
+    class(physics_t), intent(inout) :: this
+    procedure(real(dp)) :: H_func
+    procedure(real(dp)), optional :: dHdT_func
+    procedure(real(dp)), optional :: dHdrho_func
+
+    this%heating%H => H_func
+    if (present(dHdT_func)) this%heating%dHdT => dHdT_func
+    if (present(dHdrho_func)) this%heating%dHdrho => dHdrho_func
+  end subroutine set_heating_funcs
 
 
   subroutine delete(this)

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -6,8 +6,6 @@ module mod_physics
   use mod_gravity, only: gravity_t, new_gravity
   use mod_hall, only: hall_t, new_hall
   use mod_thermal_conduction, only: conduction_t, new_conduction
-  use mod_radiative_cooling, only: cooling_t, new_cooling
-  use mod_heating, only: heating_t, new_heating
   use mod_heatloss, only: heatloss_t, new_heatloss
   implicit none
 
@@ -18,8 +16,6 @@ module mod_physics
     type(gravity_t) :: gravity
     type(hall_t) :: hall
     type(conduction_t) :: conduction
-    type(cooling_t) :: cooling
-    type(heating_t) :: heating
     type(heatloss_t) :: heatloss
   contains
     procedure, public :: set_resistivity_funcs
@@ -44,11 +40,7 @@ contains
     physics%gravity = new_gravity()
     physics%hall = new_hall(settings, background)
     physics%conduction = new_conduction(settings, background)
-    physics%cooling = new_cooling(settings, background)
-    physics%heating = new_heating(settings, background)
-    physics%heatloss = new_heatloss( &
-      settings, background, physics%cooling, physics%heating &
-    )
+    physics%heatloss = new_heatloss(settings, background)
   end function new_physics
 
 
@@ -113,8 +105,8 @@ contains
     procedure(real(dp)) :: lambdaT_func
     procedure(real(dp)), optional :: dlambdadT_func
 
-    this%cooling%lambdaT => lambdaT_func
-    if (present(dlambdadT_func)) this%cooling%dlambdadT => dlambdadT_func
+    this%heatloss%cooling%lambdaT => lambdaT_func
+    if (present(dlambdadT_func)) this%heatloss%cooling%dlambdadT => dlambdadT_func
   end subroutine set_cooling_funcs
 
 
@@ -124,9 +116,9 @@ contains
     procedure(real(dp)), optional :: dHdT_func
     procedure(real(dp)), optional :: dHdrho_func
 
-    this%heating%H => H_func
-    if (present(dHdT_func)) this%heating%dHdT => dHdT_func
-    if (present(dHdrho_func)) this%heating%dHdrho => dHdrho_func
+    this%heatloss%heating%H => H_func
+    if (present(dHdT_func)) this%heatloss%heating%dHdT => dHdT_func
+    if (present(dHdrho_func)) this%heatloss%heating%dHdrho => dHdrho_func
   end subroutine set_heating_funcs
 
 
@@ -136,8 +128,6 @@ contains
     call this%gravity%delete()
     call this%hall%delete()
     call this%conduction%delete()
-    call this%cooling%delete()
-    call this%heating%delete()
     call this%heatloss%delete
   end subroutine delete
 

--- a/src/physics/mod_radiative_cooling.f08
+++ b/src/physics/mod_radiative_cooling.f08
@@ -20,9 +20,6 @@ module mod_radiative_cooling
   type, public :: cooling_t
     procedure(real(dp)), pointer, nopass :: lambdaT
     procedure(real(dp)), pointer, nopass :: dlambdadT
-    procedure(real(dp)), pointer, nopass :: L0
-    procedure(real(dp)), pointer, nopass :: dLdT
-    procedure(real(dp)), pointer, nopass :: dLdrho
     logical, private :: is_initialised
 
   contains
@@ -43,9 +40,6 @@ contains
     cooling%is_initialised = .false.
     cooling%lambdaT => get_lambdaT
     cooling%dlambdadT => get_dlambdadT
-    cooling%L0 => get_L0
-    cooling%dLdT => get_dLdT
-    cooling%dLdrho => get_dLdrho
   end function new_cooling
 
 
@@ -70,36 +64,12 @@ contains
   end subroutine initialise
 
 
-  real(dp) function get_L0(x)
-    real(dp), intent(in) :: x
-
-    get_L0 = 0.0_dp
-  end function get_L0
-
-
-  real(dp) function get_dLdT(x)
-    real(dp), intent(in) :: x
-
-    get_dLdT = 0.0_dp
-    if (.not. settings%physics%cooling%is_enabled()) return
-
-    get_dLdT = background%density%rho0(x) * get_dlambdadT(x)
-  end function get_dLdT
-
-
-  real(dp) function get_dLdrho(x)
-    real(dp), intent(in) :: x
-
-    get_dLdrho = 0.0_dp
-    if (.not. settings%physics%cooling%is_enabled()) return
-
-    get_dLdrho = get_lambdaT(x)
-  end function get_dLdrho
-
-
   real(dp) function get_lambdaT(x)
     use mod_cooling_curves, only: get_rosner_lambdaT, get_interpolated_lambdaT
     real(dp), intent(in) :: x
+
+    get_lambdaT = 0.0_dp
+    if (.not. settings%physics%cooling%is_enabled()) return
 
     if (settings%physics%cooling%get_cooling_curve() == ROSNER) then
       get_lambdaT = get_rosner_lambdaT(x, settings, background)
@@ -112,6 +82,9 @@ contains
   real(dp) function get_dlambdadT(x)
     use mod_cooling_curves, only: get_rosner_dlambdadT, get_interpolated_dlambdadT
     real(dp), intent(in) :: x
+
+    get_dlambdadT = 0.0_dp
+    if (.not. settings%physics%cooling%is_enabled()) return
 
     if (settings%physics%cooling%get_cooling_curve() == ROSNER) then
       get_dlambdadT = get_rosner_dlambdadT(x, settings, background)
@@ -129,9 +102,6 @@ contains
     nullify(background)
     nullify(this%lambdaT)
     nullify(this%dlambdadT)
-    nullify(this%L0)
-    nullify(this%dLdT)
-    nullify(this%dLdrho)
     this%is_initialised = .false.
     call deallocate_cooling_curves()
   end subroutine delete

--- a/src/settings/mod_physics_settings.f08
+++ b/src/settings/mod_physics_settings.f08
@@ -112,8 +112,14 @@ contains
   end subroutine enable_cooling
 
 
-  pure subroutine enable_heating(this)
+  pure subroutine enable_heating(this, force_thermal_balance)
     class(physics_t), intent(inout) :: this
+    logical, intent(in), optional :: force_thermal_balance
+    logical :: force_balance
+
+    force_balance = .true.
+    if (present(force_thermal_balance)) force_balance = force_thermal_balance
+    this%heating%force_thermal_balance = force_balance
     call this%heating%enable()
   end subroutine enable_heating
 

--- a/src/settings/mod_physics_settings.f08
+++ b/src/settings/mod_physics_settings.f08
@@ -59,6 +59,7 @@ contains
 
     physics%flow = new_flow_settings()
     physics%cooling = new_cooling_settings()
+    physics%heating = new_heating_settings()
     physics%gravity = new_gravity_settings()
     physics%resistivity = new_resistivity_settings()
     physics%viscosity = new_viscosity_settings()

--- a/src/settings/physics/mod_cooling_settings.f08
+++ b/src/settings/physics/mod_cooling_settings.f08
@@ -7,7 +7,6 @@ module mod_cooling_settings
     integer, private :: n_interp
     character(:), private, allocatable :: cooling_curve
     logical, private :: has_cooling
-    logical :: ensure_equilibrium
 
   contains
 
@@ -30,7 +29,6 @@ contains
     cooling%has_cooling = .false.
     call cooling%set_cooling_curve("jc_corona")
     call cooling%set_interpolation_points(4000)
-    cooling%ensure_equilibrium = .true.
   end function new_cooling_settings
 
 

--- a/src/settings/physics/mod_heating_settings.f08
+++ b/src/settings/physics/mod_heating_settings.f08
@@ -4,6 +4,7 @@ module mod_heating_settings
   private
 
   type, public :: heating_settings_t
+    logical :: force_thermal_balance
     logical, private :: has_heating
 
   contains
@@ -20,6 +21,7 @@ contains
   pure function new_heating_settings() result(heating)
     type(heating_settings_t) :: heating
     heating%has_heating = .false.
+    heating%force_thermal_balance = .true.
   end function new_heating_settings
 
 

--- a/tests/regression_tests/test_discrete_alfven.py
+++ b/tests/regression_tests/test_discrete_alfven.py
@@ -13,6 +13,8 @@ class TestDiscreteAlfvenQR(RegressionTest):
     parameters = {"k2": 1.0, "k3": 0.05, "j0": 0.125, "delta": 0.2}
     physics_settings = {
         "radiative_cooling": True,
+        "heating": True,
+        "force_thermal_balance": True,
         "cooling_curve": "rosner",
         "parallel_conduction": True,
         "perpendicular_conduction": False,

--- a/tests/regression_tests/test_gold_hoyle.py
+++ b/tests/regression_tests/test_gold_hoyle.py
@@ -13,6 +13,8 @@ class TestGoldHoyleQR(RegressionTest):
     parameters = {"k2": 1.0, "k3": 1.0, "cte_rho0": 1.0, "cte_T0": 0.001, "alpha": 20.0}
     physics_settings = {
         "radiative_cooling": True,
+        "heating": True,
+        "force_thermal_balance": True,
         "cooling_curve": "rosner",
         "parallel_conduction": True,
         "perpendicular_conduction": False,

--- a/tests/regression_tests/test_magnetothermal_modes.py
+++ b/tests/regression_tests/test_magnetothermal_modes.py
@@ -19,6 +19,8 @@ class MagnetoThermalModes(RegressionTest):
     parameters = {"k2": 0.0, "k3": 1.0, "cte_T0": 1.0}
     physics_settings = {
         "radiative_cooling": True,
+        "heating": True,
+        "force_thermal_balance": True,
         "cooling_curve": "rosner",
         "parallel_conduction": True,
         "perpendicular_conduction": False,

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -86,6 +86,7 @@ set( test_sources
         mod_test_eigenfunctions.pf
         mod_test_cooling.pf
         mod_test_cooling_tables.pf
+        mod_test_heating.pf
         mod_test_resistivity.pf
         mod_test_conduction.pf
         mod_test_boundaries.pf

--- a/tests/unit_tests/mod_test_cooling.pf
+++ b/tests/unit_tests/mod_test_cooling.pf
@@ -68,8 +68,8 @@ contains
     integer   :: i
 
     call set_name("cooling curve: rosner (lambdaT)")
-    call settings%physics%cooling%set_cooling_curve("rosner")
-    call physics%cooling%initialise()
+    call settings%physics%enable_cooling(cooling_curve="rosner")
+    call physics%heatloss%cooling%initialise()
     do i = 1, pts
       expected(i) = 10.0d0**( &
         logxi_expected(i) + alpha_expected(i) * logT0values(i) &
@@ -86,8 +86,8 @@ contains
     integer :: i
 
     call set_name("cooling curve: rosner (dlambdadT)")
-    call settings%physics%cooling%set_cooling_curve("rosner")
-    call physics%cooling%initialise()
+    call settings%physics%enable_cooling(cooling_curve="rosner")
+    call physics%heatloss%cooling%initialise()
 
     do i = 1, pts
       expected(i) = alpha_expected(i) * 10.0_dp**( &

--- a/tests/unit_tests/mod_test_cooling_tables.pf
+++ b/tests/unit_tests/mod_test_cooling_tables.pf
@@ -53,7 +53,7 @@ contains
   subroutine set_cooling_curve(name)
     character(len=*), intent(in) :: name
     call settings%physics%enable_cooling(cooling_curve=name)
-    call physics%cooling%initialise()
+    call physics%heatloss%cooling%initialise()
   end subroutine set_cooling_curve
 
 
@@ -89,6 +89,18 @@ contains
       actual_vals(i) = func(xvals(i))
     end do
   end function get_actual
+
+
+  function get_dLdT() result(dLdT_vals)
+    real(dp) :: dLdT_vals(size(xvals))
+    dLdT_vals = physics%heatloss%get_dLdT(xvals)
+  end function get_dLdT
+
+
+  function get_dLdrho() result(dLdrho_vals)
+    real(dp) :: dLdrho_vals(size(xvals))
+    dLdrho_vals = physics%heatloss%get_dLdrho(xvals)
+  end function get_dLdrho
 
 
   function get_brehmstrahlung_lambda(T0, Tvals, Lvals) result(lambdavals)
@@ -146,9 +158,9 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(100.0d0, 3500.0d0, 100) / unit_temperature
     expected = 0.0_dp
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_jc_corona_below
 
@@ -160,10 +172,10 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(1.0d8, 1.0d9, 100) / unit_temperature
     expected = get_brehmstrahlung_lambda(T0vals, logT_jccorona, logL_jccorona)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
     expected = get_brehmstrahlung_dlambda(T0vals, logT_jccorona, logL_jccorona)
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_jc_corona_above
 
@@ -175,7 +187,7 @@ contains
     call allocate_arrays(pts=21)
     T0vals = 10.0_dp ** logT_jccorona(20:40) / unit_temperature
     expected = 10.0_dp ** logL_jccorona(20:40) / unit_lambdaT
-    actual = get_actual(physics%cooling%lambdaT)
+    actual = get_actual(physics%heatloss%cooling%lambdaT)
     ! approximately equal due to interpolation
     @assertEqual(expected, actual, tolerance=1.0d-1)
   end subroutine test_cooling_curve_jc_corona
@@ -188,9 +200,9 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(1.0d0, 95.0d0, 100) / unit_temperature
     expected = 0.0_dp
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_dalgarno_below
 
@@ -202,10 +214,10 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(1.1d9, 1.0d10, 100) / unit_temperature
     expected = get_brehmstrahlung_lambda(T0vals, logT_dalgarno, logL_dalgarno)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
     expected = get_brehmstrahlung_dlambda(T0vals, logT_dalgarno, logL_dalgarno)
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_dalgarno_above
 
@@ -217,7 +229,7 @@ contains
     call allocate_arrays(pts=41)
     T0vals = 10.0d0 ** logT_dalgarno(20:60) / unit_temperature
     expected = 10.0d0 ** logL_dalgarno(20:60) / unit_lambdaT
-    actual = get_actual(physics%cooling%lambdaT)
+    actual = get_actual(physics%heatloss%cooling%lambdaT)
     @assertEqual(expected, actual, tolerance=2.0d-1)
   end subroutine test_cooling_curve_dalgarno
 
@@ -229,9 +241,9 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(1.0d0, 95.0d0, 100) / unit_temperature
     expected = 0.0_dp
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_ml_solar_below
 
@@ -243,10 +255,10 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(1.1d9, 1.0d10, 100) / unit_temperature
     expected = get_brehmstrahlung_lambda(T0vals, logT_mlsolar, logL_mlsolar)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
     expected = get_brehmstrahlung_dlambda(T0vals, logT_mlsolar, logL_mlsolar)
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_ml_solar_above
 
@@ -258,7 +270,7 @@ contains
     call allocate_arrays(pts=41)
     T0vals = 10.0d0 ** logT_mlsolar(20:60) / unit_temperature
     expected = 10.0_dp ** logL_mlsolar(20:60) / unit_lambdaT
-    actual = get_actual(physics%cooling%lambdaT)
+    actual = get_actual(physics%heatloss%cooling%lambdaT)
     @assertEqual(expected, actual, tolerance=2.0d-1)
   end subroutine test_cooling_curve_ml_solar
 
@@ -270,9 +282,9 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(250.0d0, 5000.0d0, 100) / unit_temperature
     expected = 0.0_dp
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_spex_below
 
@@ -284,10 +296,10 @@ contains
     call allocate_arrays(pts=100)
     T0vals = linspace(5.0d8, 1.0d10, 100) / unit_temperature
     expected = get_brehmstrahlung_lambda(T0vals, logT_spex, logL_spex)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
     expected = get_brehmstrahlung_dlambda(T0vals, logT_spex, logL_spex)
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_spex_above
 
@@ -299,7 +311,7 @@ contains
     call allocate_arrays(pts=76)
     T0vals = 10.0d0 ** logT_spex(25:100) / unit_temperature
     expected = 10.0_dp ** logL_spex(25:100) / unit_lambdaT
-    actual = get_actual(physics%cooling%lambdaT)
+    actual = get_actual(physics%heatloss%cooling%lambdaT)
     @assertEqual(expected, actual, tolerance=1.0d-1)
   end subroutine test_cooling_curve_spex
 
@@ -310,9 +322,9 @@ contains
     call set_cooling_curve("spex_dalgarno")
     call allocate_arrays(pts=100)
     T0vals = linspace(1.0d0, 9.5d0, 100) / unit_temperature
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_spex_dalgarno_below
 
@@ -326,12 +338,12 @@ contains
     expected = get_brehmstrahlung_lambda( &
       T0vals, get_spex_dm_T_table(), get_spex_dm_L_table() &
     )
-    actual = get_actual(physics%cooling%dLdrho)
+    actual = get_dLdrho()
     @assertEqual(expected, actual, tolerance=TOL)
     expected = get_brehmstrahlung_dlambda( &
       T0vals, get_spex_dm_T_table(), get_spex_dm_L_table() &
     )
-    actual = get_actual(physics%cooling%dLdT)
+    actual = get_dLdT()
     @assertEqual(expected, actual, tolerance=TOL)
   end subroutine test_cooling_curve_spex_dalgarno_above
 
@@ -347,7 +359,7 @@ contains
     call get_cooling_table("spex_dalgarno", spex_dm_T_table, spex_dm_L_table)
     T0vals = 10.0d0 ** spex_dm_T_table(70:150) / unit_temperature
     expected = 10.0_dp ** spex_dm_L_table(70:150) / unit_lambdaT
-    actual = get_actual(physics%cooling%lambdaT)
+    actual = get_actual(physics%heatloss%cooling%lambdaT)
     @assertEqual(expected, actual, tolerance=2.0d-1)
   end subroutine test_cooling_curve_spex_dalgarno
 

--- a/tests/unit_tests/mod_test_heating.pf
+++ b/tests/unit_tests/mod_test_heating.pf
@@ -1,0 +1,86 @@
+module mod_test_heating
+  use mod_suite_utils
+  use funit
+  implicit none
+
+  real(dp), allocatable :: xvals(:)
+  type(settings_t) :: settings
+  type(physics_t) :: physics
+  type(background_t) :: background
+
+contains
+
+  @before
+  subroutine init_test()
+    settings = get_settings()
+    background = get_background()
+    physics = get_physics(settings, background)
+    call set_default_units(settings)
+
+    call background%set_density_funcs(rho0_func=rho0_func)
+    call background%set_temperature_funcs(T0_func=T0_func, dT0_func=dT0_func)
+  end subroutine init_test
+
+
+  @after
+  subroutine teardown_test()
+    if (allocated(xvals)) deallocate(xvals)
+    call settings%delete()
+    call background%delete()
+    call physics%delete()
+  end subroutine teardown_test
+
+  subroutine allocate_arrays(pts)
+    integer, intent(in) :: pts
+    allocate(xvals(pts))
+    xvals = linspace(0.0_dp, 3.0_dp, pts)
+  end subroutine allocate_arrays
+
+
+  real(dp) function rho0_func()
+    rho0_func = 1.0_dp
+  end function rho0_func
+
+  real(dp) function T0_func(x)
+    real(dp), intent(in) :: x
+    T0_func = 2.0_dp * x
+  end function T0_func
+
+  real(dp) function dT0_func()
+    dT0_func = 2.0_dp
+  end function dT0_func
+
+
+  @test
+  subroutine test_heating_set_H()
+    call set_name("heating: setting H")
+    call physics%set_heating_funcs(H_func=T0_func)
+    call allocate_arrays(pts=100)
+    @assertEqual(-2.0_dp * xvals, physics%heatloss%get_L0(xvals), tolerance=TOL)
+    @assertEqual(0.0_dp, physics%heatloss%get_dLdT(xvals), tolerance=TOL)
+    @assertEqual(0.0_dp, physics%heatloss%get_dLdrho(xvals), tolerance=TOL)
+  end subroutine test_heating_set_H
+
+
+  @test
+  subroutine test_heating_set_dHdT()
+    call set_name("heating: setting dHdT")
+    call physics%set_heating_funcs(H_func=T0_func, dHdT_func=dT0_func)
+    call allocate_arrays(pts=100)
+    @assertEqual(-2.0_dp * xvals, physics%heatloss%get_L0(xvals), tolerance=TOL)
+    @assertEqual(-2.0_dp, physics%heatloss%get_dLdT(xvals), tolerance=TOL)
+    @assertEqual(0.0_dp, physics%heatloss%get_dLdrho(xvals), tolerance=TOL)
+  end subroutine test_heating_set_dHdT
+
+
+  @test
+  subroutine test_heating_set_dHdrho()
+    call set_name("heating: setting dHdrho")
+    call physics%set_heating_funcs(H_func=rho0_func, dHdrho_func=T0_func)
+    call allocate_arrays(pts=100)
+    @assertEqual(-1.0_dp, physics%heatloss%get_L0(xvals), tolerance=TOL)
+    @assertEqual(0.0_dp, physics%heatloss%get_dLdT(xvals), tolerance=TOL)
+    @assertEqual(-2.0_dp * xvals, physics%heatloss%get_dLdrho(xvals), tolerance=TOL)
+  end subroutine test_heating_set_dHdrho
+
+end module mod_test_heating


### PR DESCRIPTION
## PR description
This PR changes how heating/cooling is treated within the code. Previously the heating function was automatically set in such a way as to satisfy thermal balance, without user-input.

With these changes the user has full control over the cooling and heating functions, as well as the option to run Legolas without a thermally balanced state. By default the heating function will be automatically set to satisfy the thermal equilibrium equation. This means that $H$ will be spatially varying but assumed to be independent of density and temperature.

Setting cooling/heating functions is done in exactly the same way as other physics functions, i.e. 
```fortran 
! for cooling
call physics%set_cooling_funcs(lambdaT_func, dlambdadT_func)
! for heating
call physics%set_heating_funcs(H_func, dHdT_func, dHdrho_func)
```
where all these functions have an interface of the form
```fortran
real(dp) function func(x)
  real(dp), intent(in) :: x 
end function func
```

## New features
**Legolas**
- Ability to run the code outside of thermal balance by enabling heating through the optional argument
  ```fortran
  call settings%physics%heating%enable_heating(force_thermal_balance=.false.)
  ```
  or in the physicslist in the parfile. This parameter is `.true.` by default
- User-customisable cooling function $\Lambda(T)$ and its temperature derivative
- User-customisable heating function $H(\rho, T)$ and its density/temperature derivative
- The cooling/heating functions are now also saved to the datfile

