### PR TITLE
Minor changes and edits related to 2.0

### DIFF
--- a/src/boundaries/smod_natural_bounds_conduction.f08
+++ b/src/boundaries/smod_natural_bounds_conduction.f08
@@ -92,7 +92,7 @@ contains
 
     Gop_min = k3 * B02 - k2 * B03 / eps
     Fop = k2 * B02 / eps + k3 * B03
-    Kp = physics%conduction%tcprefactor(x)
+    Kp = physics%conduction%get_tcprefactor(x)
     Kp_plus = Kp + dkappa_perp_dB2
     Kp_plusplus = dkappa_perp_dB2 - (B01**2 * Kp_plus / B0**2)
 

--- a/src/dataIO/mod_console.f08
+++ b/src/dataIO/mod_console.f08
@@ -81,7 +81,7 @@ contains
     integer, intent(in) :: lines
     integer :: i
 
-    if (logger%get_logging_level() >= 1) then
+    if (logger%get_logging_level() > 1) then
       do i = 1, lines
         write(*, *) ""
       end do
@@ -91,14 +91,15 @@ contains
 
   subroutine log_grid_info(settings)
     type(settings_t), intent(in) :: settings
+    integer :: dims
 
     call logger%info("              << Grid settings >>")
-    call logger%info("geometry           : " // settings%grid%get_geometry())
-    call logger%info("grid start         : " // str(settings%grid%get_grid_start()))
-    call logger%info("grid end           : " // str(settings%grid%get_grid_end()))
-    call logger%info("gridpoints (base)  : " // str(settings%grid%get_gridpts()))
-    call logger%info("gridpoints (Gauss) : " // str(settings%grid%get_gauss_gridpts()))
-    call logger%info("gridpoints (matrix): " // str(settings%dims%get_dim_matrix()))
+    call logger%info("geometry         : " // settings%grid%get_geometry())
+    call logger%info("grid start       : " // str(settings%grid%get_grid_start()))
+    call logger%info("grid end         : " // str(settings%grid%get_grid_end()))
+    call logger%info("points base grid : " // str(settings%grid%get_gridpts()))
+    dims = settings%dims%get_dim_matrix()
+    call logger%info("matrix dimensions: " // str(dims) // " x " // str(dims))
   end subroutine log_grid_info
 
 
@@ -135,20 +136,22 @@ contains
     subroutine log_flow_info()
       logical :: flow
       flow = settings%physics%flow%is_enabled()
+      if (.not. flow) return
       call logger%info("flow                     : " // str(flow))
     end subroutine log_flow_info
 
     subroutine log_gravity_info()
       logical :: gravity
       gravity = settings%physics%gravity%is_enabled()
+      if (.not. gravity) return
       call logger%info("external gravity         : " // str(gravity))
     end subroutine log_gravity_info
 
     subroutine log_cooling_info()
       logical :: cooling
       cooling = settings%physics%cooling%is_enabled()
-      call logger%info("radiative cooling        : " // str(cooling))
       if (.not. cooling) return
+      call logger%info("radiative cooling        : " // str(cooling))
       call logger%info("  cooling curve          : " // &
         trim(adjustl(settings%physics%cooling%get_cooling_curve())) &
       )
@@ -157,8 +160,8 @@ contains
     subroutine log_heating_info()
       logical :: heating
       heating = settings%physics%heating%is_enabled()
-      call logger%info("heating                  : " // str(heating))
       if (.not. heating) return
+      call logger%info("heating                  : " // str(heating))
       call logger%info("  forcing thermal balance: " // &
         str(settings%physics%heating%force_thermal_balance) &
       )
@@ -167,8 +170,8 @@ contains
     subroutine log_parallel_conduction_info()
       logical :: tc_para
       tc_para = settings%physics%conduction%has_parallel_conduction()
-      call logger%info("parallel conduction      : " // str(tc_para))
       if (.not. tc_para) return
+      call logger%info("parallel conduction      : " // str(tc_para))
       if (settings%physics%conduction%has_fixed_tc_para()) then
         call logger%info("  fixed value            : " // &
           str(settings%physics%conduction%get_fixed_tc_para(), fmt=exp_fmt) &
@@ -179,8 +182,8 @@ contains
     subroutine log_perpendicular_conduction_info()
       logical :: tc_perp
       tc_perp = settings%physics%conduction%has_perpendicular_conduction()
-      call logger%info("perpendicular conduction : " // str(tc_perp))
       if (.not. tc_perp) return
+      call logger%info("perpendicular conduction : " // str(tc_perp))
       if (settings%physics%conduction%has_fixed_tc_perp()) then
         call logger%info("  fixed value            : " // &
           str(settings%physics%conduction%get_fixed_tc_perp(), fmt=exp_fmt) &
@@ -191,8 +194,8 @@ contains
     subroutine log_resistivity_info()
       logical :: resistivity
       resistivity = settings%physics%resistivity%is_enabled()
-      call logger%info("resistivity              : " // str(resistivity))
       if (.not. resistivity) return
+      call logger%info("resistivity              : " // str(resistivity))
       if (settings%physics%resistivity%has_fixed_resistivity()) then
         call logger%info("  fixed eta value        : " // &
           str(settings%physics%resistivity%get_fixed_resistivity(), fmt=exp_fmt) &
@@ -203,8 +206,8 @@ contains
     subroutine log_viscosity_info()
       logical :: viscosity
       viscosity = settings%physics%viscosity%is_enabled()
-      call logger%info("viscosity                : " // str(viscosity))
       if (.not. viscosity) return
+      call logger%info("viscosity                : " // str(viscosity))
       call logger%info( &
         "  viscosity value        : " // &
         str(settings%physics%viscosity%get_viscosity_value()) &
@@ -218,8 +221,8 @@ contains
     subroutine log_hall_info()
       logical :: hall
       hall = settings%physics%hall%is_enabled()
-      call logger%info("hall mhd                 : " // str(hall))
       if (.not. hall) return
+      call logger%info("hall mhd                 : " // str(hall))
       call logger%info( &
         "  by substitution        : " // &
         str(settings%physics%hall%is_using_substitution()) &
@@ -276,13 +279,12 @@ contains
       "write derived eigenfunctions : " &
       // str(settings%io%write_derived_eigenfunctions) &
     )
+    if (.not. settings%io%write_ef_subset) return
     call logger%info( &
       "write eigenfunction subset : " // str(settings%io%write_ef_subset) &
     )
-    if (settings%io%write_ef_subset) then
-      call logger%info("    subset center : " // str(settings%io%ef_subset_center))
-      call logger%info("    subset radius : " // str(settings%io%ef_subset_radius))
-    end if
+    call logger%info("    subset center : " // str(settings%io%ef_subset_center))
+    call logger%info("    subset radius : " // str(settings%io%ef_subset_radius))
   end subroutine log_io_info
 
 end module mod_console

--- a/src/equilibria/smod_user_defined.f08
+++ b/src/equilibria/smod_user_defined.f08
@@ -60,10 +60,8 @@ contains
     B03 = x
   end function B03
 
-  real(dp) function g0(x, settings, background)
+  real(dp) function g0(x)
     real(dp), intent(in) :: x
-    type(settings_t), intent(in) :: settings
-    type(background_t), intent(in) :: background
     g0 = 1.0_dp / x**2
   end function g0
 

--- a/src/main.f08
+++ b/src/main.f08
@@ -10,6 +10,7 @@ program legolas
   use mod_global_variables, only: dp, str_len, initialise_globals
   use mod_matrix_structure, only: matrix_t
   use mod_equilibrium, only: set_equilibrium
+  use mod_inspections, only: do_equilibrium_inspections
   use mod_matrix_manager, only: build_matrices
   use mod_solvers, only: solve_evp
   use mod_output, only: datfile_path, create_datfile
@@ -56,6 +57,7 @@ program legolas
   timer%init_time = timer%end_timer()
 
   call print_console_info(settings)
+  call do_equilibrium_inspections(settings, grid, background, physics)
 
   call timer%start_timer()
   call build_matrices(matrix_B, matrix_A, settings, grid, background, physics)

--- a/src/matrices/smod_conduction_matrix.f08
+++ b/src/matrices/smod_conduction_matrix.f08
@@ -107,8 +107,8 @@ contains
     dkappa_perp_dT = physics%conduction%dtcperpdT(x_gauss)
     dkappa_perp_dB2 = physics%conduction%dtcperpdB2(x_gauss)
     ! prefactors
-    Kp = physics%conduction%tcprefactor(x_gauss)
-    diffKp = physics%conduction%dtcprefactordr(x_gauss)
+    Kp = physics%conduction%get_tcprefactor(x_gauss)
+    diffKp = physics%conduction%get_dtcprefactordr(x_gauss)
     Kp_plus = Kp + dkappa_perp_dB2
     Kp_plusplus = dkappa_perp_dB2 - (B01**2 * Kp_plus / B0**2)
     ! operators

--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -222,8 +222,6 @@ contains
   !!          not balanced, contains NaN or if density/temperature contains
   !!          negative values.
   subroutine set_equilibrium(settings, grid, background, physics)
-    use mod_inspections, only: perform_NaN_and_negative_checks, perform_sanity_checks
-
     type(settings_t), intent(inout) :: settings
     type(grid_t), intent(inout) :: grid
     type(background_t), intent(inout) :: background
@@ -235,9 +233,6 @@ contains
     call set_equilibrium_values(settings, grid, background, physics)
     call grid%initialise()
 
-    ! Do initial checks for NaN and negative density/temperature
-    call perform_NaN_and_negative_checks(settings, grid, background, physics)
-
     if (settings%physics%cooling%is_enabled()) then
       call physics%heatloss%cooling%initialise()
     end if
@@ -245,9 +240,6 @@ contains
       physics%conduction, grid &
     )
     call physics%hall%validate_scale_ratio(grid%gaussian_grid)
-
-    ! Do final sanity checks on values
-    call perform_sanity_checks(settings, grid, background, physics)
   end subroutine set_equilibrium
 
 

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -17,143 +17,141 @@ module mod_inspections
 
   private
 
-  public :: perform_NaN_and_negative_checks
-  public :: perform_sanity_checks
-  public :: check_wavenumbers
+  ! needs explicit interface to pass procedure pointers
+  interface
+    real(dp) function dp_func(x)
+      import dp
+      real(dp), intent(in) :: x
+    end function dp_func
+  end interface
+
+  public :: do_equilibrium_inspections
 
 contains
 
-  !> General routine to do initial sanity checks on the various equilibrium attributes.
-  !! We check the equilibrium arrays for NaN and see if all density and temperature
-  !! values are positive.
-  subroutine perform_NaN_and_negative_checks(settings, grid, background, physics)
+  subroutine do_equilibrium_inspections(settings, grid, background, physics)
     type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
+
+    if (nan_values_present(background, physics, grid)) return
+    if (negative_values_present(background, grid)) return
+    if (.not. wave_numbers_are_valid(geometry=settings%grid%get_geometry())) return
+    if (B01_and_cylindrical(settings, grid, background)) return
+    call validate_on_axis_values(settings, background)
+    call validate_equilibrium_conditions(settings, grid, background, physics)
+  end subroutine do_equilibrium_inspections
+
+
+  logical function contains_negative(func, grid)
+    procedure(dp_func), pointer :: func
+    type(grid_t), intent(in) :: grid
+    contains_negative = any(is_negative(from_function(func, grid%gaussian_grid)))
+  end function contains_negative
+
+
+  logical function contains_NaN(func, grid)
+    procedure(dp_func), pointer :: func
+    type(grid_t), intent(in) :: grid
+    contains_NaN = any(is_NaN(from_function(func, grid%gaussian_grid)))
+  end function contains_NaN
+
+
+  logical function nan_values_present(background, physics, grid)
+    type(background_t), intent(in) :: background
+    type(physics_t), intent(in) :: physics
+    type(grid_t), intent(in) :: grid
     character(50) :: name
 
+    nan_values_present = .false.
     name = ""
-    ! TODO: is there an easier way to do this?
-    if (any(is_negative(from_function(background%density%rho0, grid%gaussian_grid)))) then
-      call logger%error("negative density encountered!")
-      return
-    end if
-    if (any( &
-      is_negative(from_function(background%temperature%T0, grid%gaussian_grid))) &
-    ) then
-      call logger%error("negative temperature encountered!")
-      return
-    end if
-    if (any(is_NaN(from_function(background%density%rho0, grid%gaussian_grid)))) then
-      name = "density"
-    else if (any( &
-      is_NaN(from_function(background%temperature%T0, grid%gaussian_grid))) &
-    ) then
-      name = "temperature"
-    else if (any( &
-      is_NaN(from_function(background%magnetic%B01, grid%gaussian_grid))) &
-    ) then
+    if (contains_NaN(background%density%rho0, grid)) then
+      name = "rho0"
+    else if (contains_NaN(background%temperature%T0, grid)) then
+      name = "T0"
+    else if (contains_NaN(background%magnetic%B01, grid)) then
       name = "B01"
-    else if (any( &
-      is_NaN(from_function(background%magnetic%B02, grid%gaussian_grid))) &
-    ) then
+    else if (contains_NaN(background%magnetic%B02, grid)) then
       name = "B02"
-    else if (any( &
-      is_NaN(from_function(background%magnetic%B03, grid%gaussian_grid))) &
-    ) then
+    else if (contains_NaN(background%magnetic%B03, grid)) then
       name = "B03"
-    else if (any( &
-      is_NaN(from_function(background%velocity%v01, grid%gaussian_grid))) &
-    ) then
+    else if (contains_NaN(background%velocity%v01, grid)) then
       name = "v01"
-    else if (any( &
-      is_NaN(from_function(background%velocity%v02, grid%gaussian_grid))) &
-    ) then
+    else if (contains_NaN(background%velocity%v02, grid)) then
       name = "v02"
-    else if (any( &
-      is_NaN(from_function(background%velocity%v03, grid%gaussian_grid))) &
-    ) then
+    else if (contains_NaN(background%velocity%v03, grid)) then
       name = "v03"
-    else if (any(is_NaN(from_function(physics%gravity%g0, grid%gaussian_grid)))) then
+    else if (contains_NaN(physics%gravity%g0, grid)) then
       name = "gravity"
     end if
-
     if (name /= "") then
       call logger%error("NaN encountered in " // adjustl(trim(name)))
-      return
+      nan_values_present = .true.
     end if
-  end subroutine perform_NaN_and_negative_checks
+  end function nan_values_present
 
 
-  !> General routine to do sanity checks on the different equilibrium types.
-  !! We check the wavenumbers and on-axis values, as well as standard
-  !! and non-adiabatic equilibrium force balance.
-  subroutine perform_sanity_checks(settings, grid, background, physics)
-    type(settings_t), intent(in) :: settings
-    type(grid_t), intent(in) :: grid
+  logical function negative_values_present(background, grid)
     type(background_t), intent(in) :: background
-    type(physics_t), intent(in) :: physics
-
-    call check_wavenumbers(geometry=settings%grid%get_geometry())
-    call check_B01_cylindrical(settings, grid, background)
-    call check_on_axis_values(settings, background)
-    call standard_equil_conditions(settings, grid, background, physics)
-    call continuity_equil_conditions(settings, grid, background)
-    call induction_equil_conditions(settings, grid, background)
-    call check_energy_balance(settings, grid, background, physics)
-  end subroutine perform_sanity_checks
-
-
-  subroutine check_B01_cylindrical(settings, grid, background)
-    type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
-    type(background_t), intent(in) :: background
+    character(50) :: name
 
-    if (.not. settings%grid%get_geometry() == "cylindrical") return
-    if (.not. all( &
-      is_zero(from_function(background%magnetic%B01, grid%gaussian_grid))) &
-    ) then
-      call logger%error( &
-        "B01 component currently not supported for cylindrical geometries!" &
-      )
+    negative_values_present = .false.
+    name = ""
+    if (contains_negative(background%density%rho0, grid)) then
+      name = "rho0"
+    else if (contains_negative(background%temperature%T0, grid)) then
+      name = "T0"
     end if
-  end subroutine check_B01_cylindrical
+    if (name /= "") then
+      call logger%error("negative values encountered in " // adjustl(trim(name)))
+      negative_values_present = .true.
+    end if
+  end function negative_values_present
 
 
-  !> Sanity check on the wavenumbers.
-  !! Checks if k2 is an integer in cylindrical geometry.
-  !! @warning An error if thrown if the geometry is cylindrical and k2 is not
-  !!          an integer.
-  subroutine check_wavenumbers(geometry)
+  logical function wave_numbers_are_valid(geometry)
     use mod_equilibrium_params, only: k2
-
     character(len=*), intent(in) :: geometry
 
+    wave_numbers_are_valid = .true.
     ! in cylindrical geometry k2 should be an integer
     if (geometry == "cylindrical" .and. .not. is_zero(abs(int(k2) - k2))) then
       call logger%error( &
         "cylindrical geometry but k2 is not an integer! Value: " // str(k2) &
       )
+      wave_numbers_are_valid = .false.
     end if
-  end subroutine check_wavenumbers
+  end function wave_numbers_are_valid
 
 
-  !> Checks if on-axis regularity conditions are satisfied in cylindrical geometry.
-  !! We check if \(B_\theta, B_z', v_\theta\) and \(v_z'\) are smaller than <tt>1e-3</tt> on-axis.
-  !! Nothing is checked if the geometry is Cartesian.
-  !! @warning Throws a warning if:
-  !!
-  !! - \(B_\theta\) is not zero on-axis.
-  !! - \(B_z'\) is not zero on-axis.
-  !! - \(v_\theta\) is not zero on-axis.
-  !! - \(v_z'\) is not zero on-axis. @endwarning
-  subroutine check_on_axis_values(settings, background)
+  logical function B01_and_cylindrical(settings, grid, background)
+    type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
+    type(background_t), intent(in) :: background
+    logical :: B01_is_zero
+
+    B01_and_cylindrical = .false.
+    if (.not. settings%grid%get_geometry() == "cylindrical") return
+
+    B01_is_zero = all( &
+      is_zero(from_function(background%magnetic%B01, grid%gaussian_grid)) &
+    )
+    if (.not. B01_is_zero) then
+      call logger%error( &
+        "B01 component currently not supported for cylindrical geometries!" &
+      )
+      B01_and_cylindrical = .true.
+    end if
+  end function B01_and_cylindrical
+
+
+  subroutine validate_on_axis_values(settings, background)
     type(settings_t), intent(in) :: settings
     type(background_t), intent(in) :: background
 
     if (settings%grid%get_geometry() == "Cartesian") return
-    if (settings%grid%get_grid_start() > 0.0_dp) return
 
     ! LCOV_EXCL_START
     if (.not. is_zero(background%magnetic%B02(0.0_dp))) then
@@ -177,314 +175,248 @@ contains
       )
     end if
     ! LCOV_EXCL_STOP
-  end subroutine check_on_axis_values
+  end subroutine validate_on_axis_values
 
 
-  !> Checks the standard force-balance equation for the equilibrium state. This
-  !! results in three expressions,
-  !! $$ \Bigl(p_0 + \frac{1}{2}B_0^2\Bigr)' + \rho_0 g + \rho_0 v_{01} v_{01}'
-  !!    - \frac{\varepsilon'}{\varepsilon}\bigl(\rho_0 v_{02}^2 - B_{02}^2\bigr) = 0, $$
-  !! $$ \rho_0 v_{01} \bigl( v_{02}' + \frac{\varepsilon'}{\varepsilon} v_{02} \bigr)
-  !!    - \frac{B_{01}}{\varepsilon} (\varepsilon B_{02})' = 0, $$
-  !! $$ \rho_0 v_{01} v_{03}' - B_{01} B_{03}' = 0, $$
-  !! and they should all be fulfilled.
-  !! @warning   Throws a warning if force-balance is not satisfied.
-  subroutine standard_equil_conditions(settings, grid, background, physics)
+  subroutine validate_equilibrium_conditions(settings, grid, background, physics)
+    use mod_check_values, only: is_zero
     type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
+    real(dp) :: values(size(grid%gaussian_grid))
 
-    real(dp) :: x
-    real(dp) :: rho0, drho0, B01, B02, dB02, B03, dB03, T0, dT0, grav
-    real(dp) :: v01, v02, v03, dv01, dv02, dv03
-    real(dp) :: eps, d_eps, r(3), discrepancy(3)
-    real(dp) :: eq_cond(settings%grid%get_gauss_gridpts(), 3)
-    integer :: i, j, counter(3)
-    logical :: satisfied(3)
-
-    satisfied = .true.
-    discrepancy = 0.0d0
-    counter = 0
-    do i = 1, settings%grid%get_gauss_gridpts()
-      x = grid%gaussian_grid(i)
-      rho0 = background%density%rho0(x)
-      drho0 = background%density%drho0(x)
-      B01 = background%magnetic%B01(x)
-      B02 = background%magnetic%B02(x)
-      B03 = background%magnetic%B03(x)
-      dB02 = background%magnetic%dB02(x)
-      dB03 = background%magnetic%dB03(x)
-      T0 = background%temperature%T0(x)
-      dT0 = background%temperature%dT0(x)
-      v01 = background%velocity%v01(x)
-      v02 = background%velocity%v02(x)
-      v03 = background%velocity%v03(x)
-      dv01 = background%velocity%dv01(x)
-      dv02 = background%velocity%dv02(x)
-      dv03 = background%velocity%dv03(x)
-      grav = physics%gravity%g0(x)
-      eps = grid%get_eps(x)
-      d_eps = grid%get_deps()
-
-      eq_cond(i, 1) = ( &
-        drho0 * T0 &
-        + rho0 * dT0 &
-        + B02 * dB02 &
-        + B03 * dB03 &
-        + rho0 * grav &
-        - (d_eps/eps) * (rho0 * v02**2 - B02**2) &
-        + rho0 * v01 * dv01 &
-      )
-      eq_cond(i, 2) = ( &
-        rho0 * v01 * (dv02 + v02 * d_eps / eps) - B01 * (dB02 + B02 * d_eps / eps) &
-      )
-      eq_cond(i, 3) = rho0 * v01 * dv03 - B01 * dB03
-
-      do j = 1, 3
-        if (.not. is_zero(abs(eq_cond(i, j)))) then
-          counter(j) = counter(j) + 1
-          satisfied(j) = .false.
-          if (abs(eq_cond(i, j)) > discrepancy(j)) then
-            discrepancy(j) = abs(eq_cond(i, j))
-            r(j) = grid%gaussian_grid(i)
-          end if
-        end if
-      end do
-    end do
-
-    do j = 1, 3
-      if (satisfied(j)) then
-        cycle
-      end if
-      ! LCOV_EXCL_START
-      call logger%warning("standard equilibrium conditions not satisfied!")
-      call logger%warning( &
-        "location of largest discrepancy (" // str(j) // "): x = " // str(r(j)) &
-      )
-      call logger%warning( &
-        "value of largest discrepancy (" // str(j) // "): " &
-        // str(discrepancy(j), fmt=exp_fmt) &
-      )
-      call logger%warning( &
-        "amount of nodes not satisfying criterion (" // str(j) // "): " &
-        // str(counter(j)) &
-      )
-      ! LCOV_EXCL_STOP
-    end do
-  end subroutine standard_equil_conditions
+    values = 0.0_dp
+    ! continuity equation
+    values = continuity_condition(grid%gaussian_grid, grid, background)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("continuity equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    ! force balance
+    values = force_balance_1_condition(grid%gaussian_grid, grid, background, physics)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("force balance 1 equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    values = force_balance_2_condition(grid%gaussian_grid, grid, background)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("force balance 2 equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    values = force_balance_3_condition(grid%gaussian_grid, background)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("force balance 3 equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    ! thermal balance
+    values = energy_balance_condition( &
+      grid%gaussian_grid, settings, grid, background, physics &
+    )
+    if (.not. all(is_zero(values))) then
+      call logger%warning("energy balance equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    ! induction equation
+    values = induction_1_condition(grid%gaussian_grid, background)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("induction 1 equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
+    values = induction_2_condition(grid%gaussian_grid, grid, background)
+    if (.not. all(is_zero(values))) then
+      call logger%warning("induction 2 equation not satisfied!")
+      call logger%warning("location of largest discrepancy: x = " // str(getx()))
+      call logger%warning("value: " // str(getval(), fmt=exp_fmt))
+    end if
 
 
-  !> Enforces the non-adiabatic force-balance equation for the equilibrium state.
-  !! This is given by
-  !! $$
-  !! T_0 \rho_0 \frac{\left(\varepsilon v_{01}\right)'}{\varepsilon}
-  !! + \rho_0 \mathscr{L}_0
-  !! - B_{01}^2\left[\frac{\kappa_{\parallel,0} - \kappa_{\perp,0}}{B_0^2} T_0'\right]'
-  !! - \frac{1}{\varepsilon}\left(\varepsilon \kappa_{\perp, 0} T_0'\right)'
-  !! + \frac{1}{(\gamma - 1)}T_0'\rho_0 v_{01} = 0
-  !! $$
-  subroutine check_energy_balance(settings, grid, background, physics)
-    type(settings_t), intent(in) :: settings
+  contains
+    real(dp) function getx()
+      getx = grid%gaussian_grid(maxloc(abs(values), dim=1))
+    end function getx
+    real(dp) function getval()
+      getval = values(maxloc(abs(values), dim=1))
+    end function getval
+  end subroutine validate_equilibrium_conditions
+
+
+  impure elemental real(dp) function continuity_condition(x, grid, background)
+    real(dp) , intent(in) :: x
+    type(grid_t), intent(in) :: grid
+    type(background_t), intent(in) :: background
+    real(dp) :: rho0, drho0, v01, dv01, eps, deps
+
+    rho0 = background%density%rho0(x)
+    drho0 = background%density%drho0(x)
+    v01 = background%velocity%v01(x)
+    dv01 = background%velocity%dv01(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
+
+    continuity_condition = drho0 * v01 + rho0 * dv01 + rho0 * v01 * deps / eps
+  end function continuity_condition
+
+
+  impure elemental real(dp) function force_balance_1_condition( &
+    x, grid, background, physics &
+  )
+    real(dp) , intent(in) :: x
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
-
-    real(dp) :: x, rho0, drho0, T0, dT0, ddT0
-    real(dp) :: B01, B02, dB02, B03, dB03, B0
-    real(dp) :: v01, dv01
-    real(dp) :: kappa_perp, dkappa_perp_dr, Kp, dKp
-    real(dp) :: L0
+    real(dp) :: rho0, drho0, B02, dB02, B03, dB03, T0, dT0, grav
+    real(dp) :: v01, v02, dv01
     real(dp) :: eps, deps
-    real(dp) :: discrepancy, r, eq_cond
-    logical :: satisfied
-    integer :: i, counter
 
-    satisfied = .true.
-    discrepancy = 0.0_dp
-    counter = 0
-    do i = 1, settings%grid%get_gauss_gridpts()
-      x = grid%gaussian_grid(i)
-      rho0 = background%density%rho0(x)
-      drho0 = background%density%drho0(x)
-      B01 = background%magnetic%B01(x)
-      B02 = background%magnetic%B02(x)
-      B03 = background%magnetic%B03(x)
-      dB02 = background%magnetic%dB02(x)
-      dB03 = background%magnetic%dB03(x)
-      B0 = background%magnetic%get_B0(x)
-      T0 = background%temperature%T0(x)
-      dT0 = background%temperature%dT0(x)
-      ddT0 = background%temperature%ddT0(x)
-      v01 = background%velocity%v01(x)
-      dv01 = background%velocity%dv01(x)
-      eps = grid%get_eps(x)
-      deps = grid%get_deps()
-      kappa_perp = physics%conduction%tcperp(x)
-      dkappa_perp_dr = physics%conduction%get_dtcperpdr(x)
-      Kp = physics%conduction%get_tcprefactor(x)
-      dKp = physics%conduction%get_dtcprefactordr(x)
-      L0 = physics%heatloss%get_L0(x)
+    rho0 = background%density%rho0(x)
+    drho0 = background%density%drho0(x)
+    B02 = background%magnetic%B02(x)
+    B03 = background%magnetic%B03(x)
+    dB02 = background%magnetic%dB02(x)
+    dB03 = background%magnetic%dB03(x)
+    T0 = background%temperature%T0(x)
+    dT0 = background%temperature%dT0(x)
+    v01 = background%velocity%v01(x)
+    v02 = background%velocity%v02(x)
+    dv01 = background%velocity%dv01(x)
+    grav = physics%gravity%g0(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
 
-      eq_cond = ( &
-        T0 * rho0 * (deps * v01 + eps * dv01) / eps &
-        + rho0 * L0 &
-        - B01**2 * (Kp * dT0 + dKp * T0) &
-        - (1.0_dp / eps) * ( &
-          deps * kappa_perp * dT0 &
-          + eps * dkappa_perp_dr * dT0 &
-          + eps * kappa_perp * ddT0 &
-        ) &
-        + (1.0_dp / settings%physics%get_gamma_1()) * dT0 * rho0 * v01 &
-      )
-      if (.not. is_zero(eq_cond)) then
-        counter = counter + 1
-        satisfied = .false.
-        if (abs(eq_cond) > discrepancy) then
-          discrepancy = abs(eq_cond)
-          r = grid%gaussian_grid(i)
-        end if
-      end if
-    end do
-
-    ! LCOV_EXCL_START
-    if (.not. satisfied) then
-      call logger%warning("energy balance not satisfied!")
-      call logger%warning("location of largest discrepancy: x = " // str(r))
-      call logger%warning( &
-        "value of largest discrepancy: " // str(discrepancy, fmt=exp_fmt) &
-      )
-      call logger%warning("amount of nodes not satisfying criterion: " // str(counter))
-    end if
-    ! LCOV_EXCL_STOP
-  end subroutine check_energy_balance
+    force_balance_1_condition = ( &
+      drho0 * T0 &
+      + rho0 * dT0 &
+      + B02 * dB02 &
+      + B03 * dB03 &
+      + rho0 * grav &
+      - (deps/eps) * (rho0 * v02**2 - B02**2) &
+      + rho0 * v01 * dv01 &
+    )
+  end function force_balance_1_condition
 
 
-  !> Checks the induction equation for the equilibrium state. The two (nonzero)
-  !! resulting expressions are
-  !! $$ (B_{01} v_{02} - (B_{02} v_{01})' = 0, $$
-  !! $$
-  !! \frac{1}{\varepsilon} \bigl(\varepsilon (B_{01}v_{03} - B_{03}v_{01}) \bigr)' = 0
-  !! $$
-  !! and should both be fulfilled.
-  !! @warning   Throws a warning if the equilibrium induction equation is not satisfied.
-  subroutine induction_equil_conditions(settings, grid, background)
-    type(settings_t), intent(in) :: settings
+  impure elemental real(dp) function force_balance_2_condition(x, grid, background)
+    real(dp), intent(in) :: x
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
 
-    real(dp)  :: x, B01, B02, dB02, B03, dB03, v01, v02, v03, dv01, dv02, dv03
-    real(dp)  :: eps, d_eps, r(2), discrepancy(2)
-    real(dp)  :: eq_cond(settings%grid%get_gauss_gridpts(), 2)
-    integer   :: i, j, counter(2)
-    logical   :: satisfied(2)
+    real(dp) :: rho0, B01, B02, dB02, v01, v02, dv02, eps, deps
 
-    satisfied = .true.
-    discrepancy = 0.0d0
-    counter = 0
-    do i = 1, settings%grid%get_gauss_gridpts()
-      x = grid%gaussian_grid(i)
-      B01 = background%magnetic%B01(x)
-      B02 = background%magnetic%B02(x)
-      B03 = background%magnetic%B03(x)
-      dB02 = background%magnetic%dB02(x)
-      dB03 = background%magnetic%dB03(x)
-      v01 = background%velocity%v01(x)
-      v02 = background%velocity%v02(x)
-      v03 = background%velocity%v03(x)
-      dv01 = background%velocity%dv01(x)
-      dv02 = background%velocity%dv02(x)
-      dv03 = background%velocity%dv03(x)
-      eps = grid%get_eps(x)
-      d_eps = grid%get_deps()
+    rho0 = background%density%rho0(x)
+    B01 = background%magnetic%B01(x)
+    B02 = background%magnetic%B02(x)
+    dB02 = background%magnetic%dB02(x)
+    v01 = background%velocity%v01(x)
+    v02 = background%velocity%v02(x)
+    dv02 = background%velocity%dv02(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
 
-      eq_cond(i, 1) = B01 * dv02 - B02 * dv01 - dB02 * v01
-      eq_cond(i, 2) = ( &
-        B01 * dv03 - dB03 * v01 - B03 * dv01 + d_eps * (B01 * v03 - B03 * v01) / eps &
-      )
-      do j = 1, 2
-        if (.not. is_zero(abs(eq_cond(i, j)))) then
-          counter(j) = counter(j) + 1
-          satisfied(j) = .false.
-          if (abs(eq_cond(i, j)) > discrepancy(j)) then
-            discrepancy(j) = abs(eq_cond(i, j))
-            r(j) = grid%gaussian_grid(i)
-          end if
-        end if
-      end do
-    end do
-
-    do j = 1, 2
-      if (satisfied(j)) then
-        cycle
-      end if
-      ! LCOV_EXCL_START
-      call logger%warning("induction equilibrium conditions not satisfied!")
-      call logger%warning( &
-        "location of largest discrepancy (" // str(j) // "): x = " // str(r(j)) &
-      )
-      call logger%warning( &
-        "value of largest discrepancy (" // str(j) // "): " &
-        // str(discrepancy(j), fmt=exp_fmt) &
-      )
-      call logger%warning( &
-        "amount of nodes not satisfying criterion (" // str(j) // "): " &
-        // str(counter(j)) &
-      )
-    end do
-    ! LCOV_EXCL_STOP
-  end subroutine induction_equil_conditions
+    force_balance_2_condition = ( &
+      rho0 * v01 * (dv02 + v02 * deps / eps) - B01 * (dB02 + B02 * deps / eps) &
+    )
+  end function force_balance_2_condition
 
 
+  impure elemental real(dp) function force_balance_3_condition(x, background)
+    real(dp), intent(in) :: x
+    type(background_t), intent(in) :: background
+    real(dp) :: rho0, B01, dB03, v01, dv03
 
-  !> Checks the continuity equation for the equilibrium state. This is given by
-  !! $$ \frac{1}{\varepsilon} \bigl( \varepsilon \rho_0 v_{01} \bigr)' = 0. $$
-  !! @warning   Throws a warning if equilibrium continuity is not satisfied.
-  subroutine continuity_equil_conditions(settings, grid, background)
+    rho0 = background%density%rho0(x)
+    B01 = background%magnetic%B01(x)
+    dB03 = background%magnetic%dB03(x)
+    v01 = background%velocity%v01(x)
+    dv03 = background%velocity%dv03(x)
+
+    force_balance_3_condition = rho0 * v01 * dv03 - B01 * dB03
+  end function force_balance_3_condition
+
+
+  impure elemental real(dp) function energy_balance_condition( &
+    x, settings, grid, background, physics &
+  )
+    real(dp), intent(in) :: x
     type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
+    type(physics_t), intent(in) :: physics
 
-    real(dp)  :: x, rho0, drho0, v01, dv01
-    real(dp)  :: eps, d_eps, r, discrepancy
-    real(dp)  :: eq_cond(settings%grid%get_gauss_gridpts())
-    integer   :: i, counter
-    logical   :: satisfied
+    real(dp) :: rho0, T0, dT0, ddT0, B01, v01, dv01
+    real(dp) :: kappa_perp, dkappa_perp_dr, Kp, dKp, L0
+    real(dp) :: eps, deps
 
-    satisfied = .true.
-    discrepancy = 0.0d0
-    counter = 0
-    do i = 1, settings%grid%get_gauss_gridpts() - 1
-      x = grid%gaussian_grid(i)
-      rho0 = background%density%rho0(x)
-      drho0 = background%density%drho0(x)
-      v01 = background%velocity%v01(x)
-      dv01 = background%velocity%dv01(x)
-      eps = grid%get_eps(x)
-      d_eps = grid%get_deps()
+    rho0 = background%density%rho0(x)
+    B01 = background%magnetic%B01(x)
+    T0 = background%temperature%T0(x)
+    dT0 = background%temperature%dT0(x)
+    ddT0 = background%temperature%ddT0(x)
+    v01 = background%velocity%v01(x)
+    dv01 = background%velocity%dv01(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
+    kappa_perp = physics%conduction%tcperp(x)
+    dkappa_perp_dr = physics%conduction%get_dtcperpdr(x)
+    Kp = physics%conduction%get_tcprefactor(x)
+    dKp = physics%conduction%get_dtcprefactordr(x)
+    L0 = physics%heatloss%get_L0(x)
 
-      eq_cond(i) = drho0 * v01 + rho0 * dv01 + rho0 * v01 * d_eps / eps
+    energy_balance_condition = ( &
+      T0 * rho0 * (deps * v01 + eps * dv01) / eps &
+      + rho0 * L0 &
+      - B01**2 * (Kp * dT0 + dKp * T0) &
+      - (1.0_dp / eps) * ( &
+        deps * kappa_perp * dT0 &
+        + eps * dkappa_perp_dr * dT0 &
+        + eps * kappa_perp * ddT0 &
+      ) &
+      + (1.0_dp / settings%physics%get_gamma_1()) * dT0 * rho0 * v01 &
+    )
+  end function energy_balance_condition
 
-      if (.not. is_zero(abs(eq_cond(i)))) then
-        counter = counter + 1
-        satisfied = .false.
-        if (abs(eq_cond(i)) > discrepancy) then
-          discrepancy = abs(eq_cond(i))
-          r = grid%gaussian_grid(i)
-        end if
-      end if
-    end do
 
-    ! LCOV_EXCL_START
-    if (.not. satisfied) then
-      call logger%warning("continuity equilibrium conditions not satisfied!")
-      call logger%warning("location of largest discrepancy: x = " // str(r))
-      call logger%warning( &
-        "value of largest discrepancy: " // str(discrepancy, fmt=exp_fmt) &
-      )
-      call logger%warning("amount of nodes not satisfying criterion: " // str(counter))
-    end if
-    ! LCOV_EXCL_STOP
-  end subroutine continuity_equil_conditions
+  impure elemental real(dp) function induction_1_condition(x, background)
+    real(dp), intent(in) :: x
+    type(background_t), intent(in) :: background
+    real(dp)  :: B01, B02, dB02, v01, dv01, dv02
+
+    B01 = background%magnetic%B01(x)
+    B02 = background%magnetic%B02(x)
+    dB02 = background%magnetic%dB02(x)
+    v01 = background%velocity%v01(x)
+    dv01 = background%velocity%dv01(x)
+    dv02 = background%velocity%dv02(x)
+
+    induction_1_condition = B01 * dv02 - B02 * dv01 - dB02 * v01
+  end function induction_1_condition
+
+
+  impure elemental real(dp) function induction_2_condition(x, grid, background)
+    real(dp), intent(in) :: x
+    type(grid_t), intent(in) :: grid
+    type(background_t), intent(in) :: background
+    real(dp)  :: B01, B03, dB03, v01, v03, dv01, dv03, eps, deps
+
+    B01 = background%magnetic%B01(x)
+    B03 = background%magnetic%B03(x)
+    dB03 = background%magnetic%dB03(x)
+    v01 = background%velocity%v01(x)
+    v03 = background%velocity%v03(x)
+    dv01 = background%velocity%dv01(x)
+    dv03 = background%velocity%dv03(x)
+    eps = grid%get_eps(x)
+    deps = grid%get_deps()
+
+    induction_2_condition = ( &
+      B01 * dv03 - dB03 * v01 - B03 * dv01 + deps * (B01 * v03 - B03 * v01) / eps &
+    )
+  end function induction_2_condition
 
 end module mod_inspections

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -321,9 +321,9 @@ contains
       eps = grid%get_eps(x)
       deps = grid%get_deps()
       kappa_perp = physics%conduction%tcperp(x)
-      dkappa_perp_dr = physics%conduction%dtcperpdr(x)
-      Kp = physics%conduction%tcprefactor(x)
-      dKp = physics%conduction%dtcprefactordr(x)
+      dkappa_perp_dr = physics%conduction%get_dtcperpdr(x)
+      Kp = physics%conduction%get_tcprefactor(x)
+      dKp = physics%conduction%get_dtcprefactordr(x)
       L0 = physics%heatloss%get_L0(x)
 
       eq_cond = ( &

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -108,10 +108,10 @@ contains
     B01 = background%magnetic%B01(x)
     eps = grid%get_eps(x)
     deps = grid%get_deps()
-    Kp = conduction%tcprefactor(x)
-    dKp = conduction%dtcprefactordr(x)
+    Kp = conduction%get_tcprefactor(x)
+    dKp = conduction%get_dtcprefactordr(x)
     tcperp = conduction%tcperp(x)
-    dtcperpdr = conduction%dtcperpdr(x)
+    dtcperpdr = conduction%get_dtcperpdr(x)
 
     H_for_thermal_balance = rho0 * cooling%lambdaT(x) + (1.0_dp / rho0) * ( &
       T0 * rho0 * (deps * v01 + eps * dv01) / eps &

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -63,40 +63,29 @@ contains
   end subroutine set_gravity_funcs
 
 
-  subroutine set_parallel_conduction_funcs( &
-    this, tcpara_func, dtcparadT_func, dtcparadr_func &
-  )
+  subroutine set_parallel_conduction_funcs(this, tcpara_func, dtcparadT_func)
     class(physics_t), intent(inout) :: this
     procedure(real(dp)) :: tcpara_func
     procedure(real(dp)), optional :: dtcparadT_func
-    procedure(real(dp)), optional :: dtcparadr_func
 
     this%conduction%tcpara => tcpara_func
     if (present(dtcparadT_func)) this%conduction%dtcparadT => dtcparadT_func
-    if (present(dtcparadr_func)) this%conduction%dtcparadr => dtcparadr_func
   end subroutine set_parallel_conduction_funcs
 
 
   subroutine set_perpendicular_conduction_funcs( &
-    this, &
-    tcperp_func, &
-    dtcperpdT_func, &
-    dtcperpdrho_func, &
-    dtcperpdB2_func, &
-    dtcperpdr_func &
+    this, tcperp_func, dtcperpdT_func, dtcperpdrho_func, dtcperpdB2_func &
   )
     class(physics_t), intent(inout) :: this
     procedure(real(dp)) :: tcperp_func
     procedure(real(dp)), optional :: dtcperpdT_func
     procedure(real(dp)), optional :: dtcperpdrho_func
     procedure(real(dp)), optional :: dtcperpdB2_func
-    procedure(real(dp)), optional :: dtcperpdr_func
 
     this%conduction%tcperp => tcperp_func
     if (present(dtcperpdT_func)) this%conduction%dtcperpdT => dtcperpdT_func
     if (present(dtcperpdrho_func)) this%conduction%dtcperpdrho => dtcperpdrho_func
     if (present(dtcperpdB2_func)) this%conduction%dtcperpdB2 => dtcperpdB2_func
-    if (present(dtcperpdr_func)) this%conduction%dtcperpdr => dtcperpdr_func
   end subroutine set_perpendicular_conduction_funcs
 
 

--- a/src/settings/mod_io_settings.f08
+++ b/src/settings/mod_io_settings.f08
@@ -4,7 +4,7 @@ module mod_io_settings
 
   private
 
-  type, public :: io_t
+  type, public :: io_settings_t
     logical, public :: write_matrices
     logical, public :: write_eigenvectors
     logical, public :: write_residuals
@@ -27,62 +27,62 @@ module mod_io_settings
     procedure, public :: should_compute_eigenvectors
     procedure, public :: set_all_io_to_false
     procedure, public :: delete
-  end type io_t
+  end type io_settings_t
 
   public :: new_io_settings
 
 
 contains
 
-  pure function new_io_settings() result(io)
+  pure function new_io_settings() result(io_settings)
     use mod_global_variables, only: NaN
 
-    type(io_t) :: io
+    type(io_settings_t) :: io_settings
 
-    io%write_matrices = .false.
-    io%write_eigenvectors = .false.
-    io%write_residuals = .false.
-    io%write_eigenfunctions = .true.
-    io%write_derived_eigenfunctions = .false.
-    io%write_ef_subset = .false.
-    io%ef_subset_radius = NaN
-    io%ef_subset_center = cmplx(NaN, NaN, kind=dp)
-    io%show_results = .true.
-    call io%set_basename_datfile("datfile")
-    call io%set_output_folder("output")
+    io_settings%write_matrices = .false.
+    io_settings%write_eigenvectors = .false.
+    io_settings%write_residuals = .false.
+    io_settings%write_eigenfunctions = .true.
+    io_settings%write_derived_eigenfunctions = .false.
+    io_settings%write_ef_subset = .false.
+    io_settings%ef_subset_radius = NaN
+    io_settings%ef_subset_center = cmplx(NaN, NaN, kind=dp)
+    io_settings%show_results = .true.
+    call io_settings%set_basename_datfile("datfile")
+    call io_settings%set_output_folder("output")
   end function new_io_settings
 
 
   pure subroutine set_basename_datfile(this, basename_datfile)
-    class(io_t), intent(inout) :: this
+    class(io_settings_t), intent(inout) :: this
     character(len=*), intent(in) :: basename_datfile
     this%basename_datfile = trim(adjustl(basename_datfile))
   end subroutine set_basename_datfile
 
 
   pure function get_basename_datfile(this) result(basename_datfile)
-    class(io_t), intent(in) :: this
+    class(io_settings_t), intent(in) :: this
     character(len=:), allocatable :: basename_datfile
     basename_datfile = trim(adjustl(this%basename_datfile))
   end function get_basename_datfile
 
 
   pure subroutine set_output_folder(this, output_folder)
-    class(io_t), intent(inout) :: this
+    class(io_settings_t), intent(inout) :: this
     character(len=*), intent(in) :: output_folder
     this%output_folder = trim(adjustl(output_folder))
   end subroutine set_output_folder
 
 
   pure function get_output_folder(this) result(output_folder)
-    class(io_t), intent(in) :: this
+    class(io_settings_t), intent(in) :: this
     character(len=:), allocatable :: output_folder
     output_folder = trim(adjustl(this%output_folder))
   end function get_output_folder
 
 
   pure logical function should_compute_eigenvectors(this)
-    class(io_t), intent(in) :: this
+    class(io_settings_t), intent(in) :: this
     should_compute_eigenvectors = ( &
       this%write_eigenfunctions &
       .or. this%write_eigenvectors &
@@ -92,7 +92,7 @@ contains
 
 
   pure subroutine set_all_io_to_false(this)
-    class(io_t), intent(inout) :: this
+    class(io_settings_t), intent(inout) :: this
     this%write_matrices = .false.
     this%write_eigenvectors = .false.
     this%write_residuals = .false.
@@ -102,7 +102,7 @@ contains
 
 
   pure subroutine delete(this)
-    class(io_t), intent(inout) :: this
+    class(io_settings_t), intent(inout) :: this
     if (allocated(this%basename_datfile)) deallocate(this%basename_datfile)
     if (allocated(this%output_folder)) deallocate(this%output_folder)
   end subroutine delete

--- a/src/settings/mod_physics_settings.f08
+++ b/src/settings/mod_physics_settings.f08
@@ -13,7 +13,7 @@ module mod_physics_settings
 
   private
 
-  type, public :: physics_t
+  type, public :: physics_settings_t
     real(dp), private :: gamma
     logical :: is_incompressible
     real(dp) :: dropoff_edge_dist
@@ -43,65 +43,65 @@ module mod_physics_settings
     procedure, public :: enable_parallel_conduction
     procedure, public :: enable_perpendicular_conduction
     procedure, public :: enable_hall
-  end type physics_t
+  end type physics_settings_t
 
   public :: new_physics_settings
 
 contains
 
-  pure function new_physics_settings() result(physics)
-    type(physics_t) :: physics
+  pure function new_physics_settings() result(physics_settings)
+    type(physics_settings_t) :: physics_settings
 
-    call physics%set_gamma(5.0_dp / 3.0_dp)
-    physics%is_incompressible = .false.
-    physics%dropoff_edge_dist = 0.0_dp
-    physics%dropoff_width = 0.0_dp
+    call physics_settings%set_gamma(5.0_dp / 3.0_dp)
+    physics_settings%is_incompressible = .false.
+    physics_settings%dropoff_edge_dist = 0.0_dp
+    physics_settings%dropoff_width = 0.0_dp
 
-    physics%flow = new_flow_settings()
-    physics%cooling = new_cooling_settings()
-    physics%heating = new_heating_settings()
-    physics%gravity = new_gravity_settings()
-    physics%resistivity = new_resistivity_settings()
-    physics%viscosity = new_viscosity_settings()
-    physics%conduction = new_conduction_settings()
-    physics%hall = new_hall_settings()
+    physics_settings%flow = new_flow_settings()
+    physics_settings%cooling = new_cooling_settings()
+    physics_settings%heating = new_heating_settings()
+    physics_settings%gravity = new_gravity_settings()
+    physics_settings%resistivity = new_resistivity_settings()
+    physics_settings%viscosity = new_viscosity_settings()
+    physics_settings%conduction = new_conduction_settings()
+    physics_settings%hall = new_hall_settings()
   end function new_physics_settings
 
 
   pure subroutine set_gamma(this, gamma)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     real(dp), intent(in) :: gamma
     this%gamma = gamma
   end subroutine set_gamma
 
 
   pure real(dp) function get_gamma(this)
-    class(physics_t), intent(in) :: this
+    class(physics_settings_t), intent(in) :: this
     get_gamma = this%gamma
   end function get_gamma
 
 
   pure real(dp) function get_gamma_1(this)
-    class(physics_t), intent(in) :: this
+    class(physics_settings_t), intent(in) :: this
     get_gamma_1 = this%get_gamma() - 1.0_dp
   end function get_gamma_1
 
 
   pure subroutine set_incompressible(this)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     this%is_incompressible = .true.
     call this%set_gamma(1.0e12_dp)
   end subroutine set_incompressible
 
 
   pure subroutine enable_flow(this)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     call this%flow%enable()
   end subroutine enable_flow
 
 
   pure subroutine enable_cooling(this, cooling_curve, interpolation_points)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     character(len=*), intent(in) :: cooling_curve
     integer, intent(in), optional :: interpolation_points
 
@@ -114,7 +114,7 @@ contains
 
 
   pure subroutine enable_heating(this, force_thermal_balance)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     logical, intent(in), optional :: force_thermal_balance
     logical :: force_balance
 
@@ -126,13 +126,13 @@ contains
 
 
   pure subroutine enable_gravity(this)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     call this%gravity%enable()
   end subroutine enable_gravity
 
 
   pure subroutine enable_resistivity(this, fixed_resistivity_value)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     real(dp), intent(in), optional :: fixed_resistivity_value
     real(dp) :: fixed_eta
 
@@ -147,7 +147,7 @@ contains
 
 
   pure subroutine enable_viscosity(this, viscosity_value, viscous_heating)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     real(dp), intent(in) :: viscosity_value
     logical, intent(in), optional :: viscous_heating
     logical :: heating
@@ -161,7 +161,7 @@ contains
 
 
   pure subroutine enable_parallel_conduction(this, fixed_tc_para_value)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     real(dp), intent(in), optional :: fixed_tc_para_value
     real(dp) :: fixed_tc_para
 
@@ -176,7 +176,7 @@ contains
 
 
   pure subroutine enable_perpendicular_conduction(this, fixed_tc_perp_value)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     real(dp), intent(in), optional :: fixed_tc_perp_value
     real(dp) :: fixed_tc_perp
 
@@ -191,7 +191,7 @@ contains
 
 
   pure subroutine enable_hall(this, electron_inertia, electron_fraction)
-    class(physics_t), intent(inout) :: this
+    class(physics_settings_t), intent(inout) :: this
     logical, intent(in), optional :: electron_inertia
     real(dp), intent(in), optional :: electron_fraction
     logical :: inertia

--- a/src/settings/mod_settings.f08
+++ b/src/settings/mod_settings.f08
@@ -1,8 +1,8 @@
 module mod_settings
   use mod_global_variables, only: str_len_arr
   use mod_dims, only: dims_t, new_block_dims
-  use mod_io_settings, only: io_t, new_io_settings
-  use mod_solver_settings, only: solvers_t, new_solver_settings
+  use mod_io_settings, only: io_settings_t, new_io_settings
+  use mod_solver_settings, only: solver_settings_t, new_solver_settings
   use mod_physics_settings, only: physics_t, new_physics_settings
   use mod_grid_settings, only: grid_settings_t, new_grid_settings
   use mod_equilibrium_settings, only: equilibrium_settings_t, new_equilibrium_settings
@@ -22,8 +22,8 @@ module mod_settings
     integer, private :: nb_eqs
 
     type(dims_t), public :: dims
-    type(io_t), public :: io
-    type(solvers_t), public :: solvers
+    type(io_settings_t), public :: io
+    type(solver_settings_t), public :: solvers
     type(physics_t), public :: physics
     type(grid_settings_t), public :: grid
     type(equilibrium_settings_t), public :: equilibrium

--- a/src/settings/mod_settings.f08
+++ b/src/settings/mod_settings.f08
@@ -3,7 +3,7 @@ module mod_settings
   use mod_dims, only: dims_t, new_block_dims
   use mod_io_settings, only: io_settings_t, new_io_settings
   use mod_solver_settings, only: solver_settings_t, new_solver_settings
-  use mod_physics_settings, only: physics_t, new_physics_settings
+  use mod_physics_settings, only: physics_settings_t, new_physics_settings
   use mod_grid_settings, only: grid_settings_t, new_grid_settings
   use mod_equilibrium_settings, only: equilibrium_settings_t, new_equilibrium_settings
   use mod_units, only: units_t, new_unit_system
@@ -24,7 +24,7 @@ module mod_settings
     type(dims_t), public :: dims
     type(io_settings_t), public :: io
     type(solver_settings_t), public :: solvers
-    type(physics_t), public :: physics
+    type(physics_settings_t), public :: physics
     type(grid_settings_t), public :: grid
     type(equilibrium_settings_t), public :: equilibrium
     type(units_t), public :: units

--- a/src/settings/mod_solver_settings.f08
+++ b/src/settings/mod_solver_settings.f08
@@ -4,7 +4,7 @@ module mod_solver_settings
 
   private
 
-  type, public :: solvers_t
+  type, public :: solver_settings_t
     character(:), allocatable, private :: solver
     character(:), allocatable, private :: arpack_mode
     integer :: number_of_eigenvalues
@@ -21,31 +21,31 @@ module mod_solver_settings
     procedure, public :: set_arpack_mode
     procedure, public :: get_arpack_mode
     procedure, public :: delete
-  end type solvers_t
+  end type solver_settings_t
 
   public :: new_solver_settings
 
 contains
 
-  pure function new_solver_settings() result(solvers)
+  pure function new_solver_settings() result(solver_settings)
     use mod_global_variables, only: dp_LIMIT, NaN
 
-    type(solvers_t) :: solvers
+    type(solver_settings_t) :: solver_settings
 
-    call solvers%set_solver("QR-invert")
-    call solvers%set_arpack_mode("general")
-    solvers%number_of_eigenvalues = 10
-    solvers%which_eigenvalues = "LM"
+    call solver_settings%set_solver("QR-invert")
+    call solver_settings%set_arpack_mode("general")
+    solver_settings%number_of_eigenvalues = 10
+    solver_settings%which_eigenvalues = "LM"
     ! these two get determined at runtime
-    solvers%maxiter = 0
-    solvers%ncv = 0
-    solvers%sigma = cmplx(NaN, NaN, kind=dp)
-    solvers%tolerance = dp_LIMIT
+    solver_settings%maxiter = 0
+    solver_settings%ncv = 0
+    solver_settings%sigma = cmplx(NaN, NaN, kind=dp)
+    solver_settings%tolerance = dp_LIMIT
   end function new_solver_settings
 
 
   pure subroutine set_solver(this, solver)
-    class(solvers_t), intent(inout) :: this
+    class(solver_settings_t), intent(inout) :: this
     character(len=*), intent(in) :: solver
 
     this%solver = trim(adjustl(solver))
@@ -53,7 +53,7 @@ contains
 
 
   pure function get_solver(this) result(solver)
-    class(solvers_t), intent(in) :: this
+    class(solver_settings_t), intent(in) :: this
     character(:), allocatable :: solver
 
     solver = trim(adjustl(this%solver))
@@ -61,7 +61,7 @@ contains
 
 
   pure subroutine set_arpack_mode(this, arpack_mode)
-    class(solvers_t), intent(inout) :: this
+    class(solver_settings_t), intent(inout) :: this
     character(len=*), intent(in) :: arpack_mode
 
     this%arpack_mode = trim(adjustl(arpack_mode))
@@ -69,7 +69,7 @@ contains
 
 
   pure function get_arpack_mode(this) result(arpack_mode)
-    class(solvers_t), intent(in) :: this
+    class(solver_settings_t), intent(in) :: this
     character(:), allocatable :: arpack_mode
 
     arpack_mode = trim(adjustl(this%arpack_mode))
@@ -77,7 +77,7 @@ contains
 
 
   pure subroutine delete(this)
-    class(solvers_t), intent(inout) :: this
+    class(solver_settings_t), intent(inout) :: this
 
     if (allocated(this%solver)) deallocate(this%solver)
     if (allocated(this%arpack_mode)) deallocate(this%arpack_mode)

--- a/src/solvers/arnoldi/mod_arpack_type.f08
+++ b/src/solvers/arnoldi/mod_arpack_type.f08
@@ -4,7 +4,7 @@
 module mod_arpack_type
   use mod_logging, only: logger, str
   use mod_global_variables, only: dp
-  use mod_solver_settings, only: solvers_t
+  use mod_solver_settings, only: solver_settings_t
   implicit none
 
   !> General type containing the ARPACK configuration.
@@ -78,7 +78,7 @@ contains
     integer, intent(in) :: mode
     !> type of the matrix B
     character(len=1), intent(in) :: bmat
-    type(solvers_t), intent(inout) :: solver_settings
+    type(solver_settings_t), intent(inout) :: solver_settings
     !> initialised arpack configuration
     type(arpack_t) :: arpack_config
 

--- a/tests/unit_tests/mod_test_conduction.pf
+++ b/tests/unit_tests/mod_test_conduction.pf
@@ -54,6 +54,26 @@ contains
     end do
   end function get_actual
 
+  function get_dtcparadr() result(dtcparadr_vals)
+    real(dp) :: dtcparadr_vals(size(xvals))
+    dtcparadr_vals = physics%conduction%get_dtcparadr(xvals)
+  end function get_dtcparadr
+
+  function get_dtcperpdr() result(dtcperpdr_vals)
+    real(dp) :: dtcperpdr_vals(size(xvals))
+    dtcperpdr_vals = physics%conduction%get_dtcperpdr(xvals)
+  end function get_dtcperpdr
+
+  function get_tcprefactor() result(tcprefactor_vals)
+    real(dp) :: tcprefactor_vals(size(xvals))
+    tcprefactor_vals = physics%conduction%get_tcprefactor(xvals)
+  end function get_tcprefactor
+
+  function get_dtcprefactordr() result(dtcprefactordr_vals)
+    real(dp) :: dtcprefactordr_vals(size(xvals))
+    dtcprefactordr_vals = physics%conduction%get_dtcprefactordr(xvals)
+  end function get_dtcprefactordr
+
 
   @test
   subroutine test_kappa_para_cte()
@@ -67,7 +87,7 @@ contains
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdrho), tolerance=TOL)
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdB2), tolerance=TOL)
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdT), tolerance=TOL)
-    @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdr), tolerance=TOL)
+    @assertEqual(0.0d0, get_dtcperpdr(), tolerance=TOL)
   end subroutine test_kappa_para_cte
 
 
@@ -91,7 +111,7 @@ contains
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdrho), tolerance=TOL)
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdB2), tolerance=TOL)
     @assertEqual(0.0d0, get_actual(physics%conduction%dtcparadT), tolerance=TOL)
-    @assertEqual(0.0d0, get_actual(physics%conduction%dtcperpdr), tolerance=TOL)
+    @assertEqual(0.0d0, get_dtcperpdr(), tolerance=TOL)
   end subroutine test_kappa_perp_cte
 
 
@@ -451,7 +471,7 @@ contains
       + dkT * 2.0d0 * xvals &
       + dkB2 * 2.0d0  * B0(xvals) * dB0(xvals) &
     ) * 1.0d8
-    actual = get_actual(physics%conduction%dtcperpdr) * 1.0d8
+    actual = get_dtcperpdr() * 1.0d8
     @assertTrue(settings%physics%conduction%is_enabled())
     @assertFalse(settings%physics%conduction%has_parallel_conduction())
     @assertTrue(settings%physics%conduction%has_perpendicular_conduction())

--- a/tests/unit_tests/mod_test_inspections.pf
+++ b/tests/unit_tests/mod_test_inspections.pf
@@ -1,7 +1,7 @@
 module mod_test_inspections
   use mod_suite_utils
   use funit
-  use mod_inspections, only: check_wavenumbers
+  use mod_inspections, only: do_equilibrium_inspections
   use mod_equilibrium_params, only: k2, k3
   use mod_global_variables, only: NaN
   implicit none
@@ -49,8 +49,7 @@ contains
 
 
   subroutine do_checks()
-    use mod_inspections, only: perform_NaN_and_negative_checks
-    call perform_NaN_and_negative_checks(settings, grid, background, physics)
+    call do_equilibrium_inspections(settings, grid, background, physics)
   end subroutine do_checks
 
 
@@ -59,7 +58,7 @@ contains
     call set_name("negative density")
     call background%set_density_funcs(rho0_func=uniform)
     call do_checks()
-    @assertExceptionRaised("negative density encountered!")
+    @assertExceptionRaised("negative values encountered in rho0")
   end subroutine test_density_negative
 
 
@@ -68,7 +67,7 @@ contains
     call set_name("negative temperature")
     call background%set_temperature_funcs(T0_func=uniform)
     call do_checks()
-    @assertExceptionRaised("negative temperature encountered!")
+    @assertExceptionRaised("negative values encountered in T0")
   end subroutine test_temperature_negative
 
 
@@ -77,7 +76,7 @@ contains
     call set_name("density NaN")
     call background%set_density_funcs(rho0_func=uniform_nan)
     call do_checks()
-    @assertExceptionRaised("NaN encountered in density")
+    @assertExceptionRaised("NaN encountered in rho0")
   end subroutine test_density_nan
 
 
@@ -86,7 +85,7 @@ contains
     call set_name("temperature NaN")
     call background%set_temperature_funcs(T0_func=uniform_nan)
     call do_checks()
-    @assertExceptionRaised("NaN encountered in temperature")
+    @assertExceptionRaised("NaN encountered in T0")
   end subroutine test_temperature_nan
 
 
@@ -166,7 +165,7 @@ contains
     call set_name("wavenumber k2 non-int in cylindrical")
     call settings%grid%set_geometry("cylindrical")
     k2 = 1.2d0
-    call check_wavenumbers(settings%grid%get_geometry())
+    call do_equilibrium_inspections(settings, grid, background, physics)
     error_msg = "cylindrical geometry but k2 is not an integer! Value: 1.20000000"
     @assertExceptionRaised(error_msg)
   end subroutine test_invalid_k2
@@ -177,7 +176,7 @@ contains
     call set_name("wavenumber k2 cylindrical")
     call settings%grid%set_geometry("cylindrical")
     k2 = 2.0d0
-    call check_wavenumbers(settings%grid%get_geometry())
+    call do_equilibrium_inspections(settings, grid, background, physics)
     @assertEqual(2.0d0, k2, tolerance=TOL)
   end subroutine test_integer_k2
 
@@ -186,7 +185,7 @@ contains
   subroutine test_k2_cartesian()
     call set_name("wavenumber k2 Cartesian")
     k2 = 0.5d0
-    call check_wavenumbers(settings%grid%get_geometry())
+    call do_equilibrium_inspections(settings, grid, background, physics)
     @assertEqual(0.5d0, k2, tolerance=TOL)
   end subroutine test_k2_cartesian
 

--- a/tests/unit_tests/mod_test_solar_atmosphere.pf
+++ b/tests/unit_tests/mod_test_solar_atmosphere.pf
@@ -44,10 +44,10 @@ contains
 
   @test
   subroutine test_sa_neg_and_nans()
-    use mod_inspections, only: perform_NaN_and_negative_checks
+    use mod_inspections, only: do_equilibrium_inspections
     call set_name("solar atmosphere (NaNs and negative values)")
     call set_solar_atmosphere(settings, background, physics)
-    call perform_NaN_and_negative_checks(settings, grid, background, physics)
+    call do_equilibrium_inspections(settings, grid, background, physics)
   end subroutine test_sa_neg_and_nans
 
 end module mod_test_solar_atmosphere


### PR DESCRIPTION
## PR description
Various minor changes and edits to the source code related to the 2.0 release.

## Overview
**Legolas**
- changed the `io` and `solver` settings objects type names to be more consistent
- renamed duplicate `physics_t` type, the one from settings is now called `physics_settings_t` 
- made radial derivative of para/perp thermal conduction into type-bound procedures instead of pointers
- logging of equilibrium inspections now occurs _after_ initialisations

## Bugfixes
**Pylbo**
- fixed duplicate Doppler continuum in hydrodynamics with flow (fixes #131)