### PR TITLE
Fix malloc error 'Incorrect checksum for freed object' for custom spacing functions

### DIFF
--- a/src/main.f08
+++ b/src/main.f08
@@ -8,7 +8,7 @@
 !! KU Leuven, Belgium.
 program legolas
   use mod_global_variables, only: dp, str_len, initialise_globals
-  use mod_matrix_structure, only: matrix_t
+  use mod_matrix_structure, only: matrix_t, new_matrix
   use mod_equilibrium, only: set_equilibrium
   use mod_inspections, only: do_equilibrium_inspections
   use mod_matrix_manager, only: build_matrices
@@ -60,6 +60,8 @@ program legolas
   call do_equilibrium_inspections(settings, grid, background, physics)
 
   call timer%start_timer()
+  matrix_A = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="A")
+  matrix_B = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="B")
   call build_matrices(matrix_B, matrix_A, settings, grid, background, physics)
   timer%matrix_time = timer%end_timer()
 
@@ -67,6 +69,7 @@ program legolas
   call timer%start_timer()
   call solve_evp(matrix_A, matrix_B, settings, omega, right_eigenvectors)
   timer%evp_time = timer%end_timer()
+  call logger%info("done.")
 
   call timer%start_timer()
   eigenfunctions = new_eigenfunctions(settings, grid, background)
@@ -102,7 +105,6 @@ contains
   !! Allocates and initialises main and global variables, then the equilibrium state
   !! and eigenfunctions are initialised and the equilibrium is set.
   subroutine initialisation()
-    use mod_matrix_structure, only: new_matrix
     use mod_input, only: read_parfile, get_parfile
     use mod_console, only: print_logo
 
@@ -126,8 +128,6 @@ contains
     end select
     call logger%debug("setting #eigenvalues to " // str(nb_evs))
     allocate(omega(nb_evs))
-    matrix_A = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="A")
-    matrix_B = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="B")
 
     ! Arnoldi solver needs this, since it always calculates an orthonormal basis
     if ( &

--- a/src/main.f08
+++ b/src/main.f08
@@ -48,7 +48,10 @@ program legolas
   settings = new_settings()
 
   call timer%start_timer()
-  call initialisation()
+
+  call read_user_parfile()
+  call print_startup_info()
+
   grid = new_grid(settings)
   background = new_background()
   physics = new_physics(settings, background)
@@ -67,6 +70,7 @@ program legolas
 
   call logger%info("solving eigenvalue problem...")
   call timer%start_timer()
+  call do_eigenvalue_problem_allocations()
   call solve_evp(matrix_A, matrix_B, settings, omega, right_eigenvectors)
   timer%evp_time = timer%end_timer()
   call logger%info("done.")
@@ -101,22 +105,24 @@ program legolas
 
 contains
 
-  !> Subroutine responsible for all initialisations.
-  !! Allocates and initialises main and global variables, then the equilibrium state
-  !! and eigenfunctions are initialised and the equilibrium is set.
-  subroutine initialisation()
-    use mod_input, only: read_parfile, get_parfile
-    use mod_console, only: print_logo
-
-    character(len=5*str_len)  :: parfile
-    integer   :: nb_evs
-
+  subroutine read_user_parfile()
+    use mod_input, only: get_parfile, read_parfile
+    character(len=5*str_len) :: parfile
     call get_parfile(parfile)
     call read_parfile(parfile, settings)
+  end subroutine read_user_parfile
 
+
+  subroutine print_startup_info()
+    use mod_console, only: print_logo
     call print_logo()
     call logger%info("the physics type is " // settings%get_physics_type())
     call logger%info("the state vector is " // str(settings%get_state_vector()))
+  end subroutine print_startup_info
+
+
+  subroutine do_eigenvalue_problem_allocations()
+    integer :: nb_evs
 
     select case(settings%solvers%get_solver())
     case ("arnoldi")
@@ -126,7 +132,7 @@ contains
     case default
       nb_evs = settings%dims%get_dim_matrix()
     end select
-    call logger%debug("setting #eigenvalues to " // str(nb_evs))
+    call logger%debug("allocating eigenvalue array of size " // str(nb_evs))
     allocate(omega(nb_evs))
 
     ! Arnoldi solver needs this, since it always calculates an orthonormal basis
@@ -144,7 +150,7 @@ contains
       call logger%debug("allocating eigenvector arrays as dummy")
       allocate(right_eigenvectors(2, 2))
     end if
-  end subroutine initialisation
+  end subroutine do_eigenvalue_problem_allocations
 
 
   !> Initialises and calculates the eigenfunctions if requested.
@@ -158,16 +164,16 @@ contains
   !> Deallocates all main variables, then calls the cleanup
   !! routines of all relevant subroutines to do the same thing.
   subroutine cleanup()
-    call matrix_A%delete_matrix()
-    call matrix_B%delete_matrix()
     deallocate(omega)
     if (allocated(right_eigenvectors)) deallocate(right_eigenvectors)
 
-    call settings%delete()
+    call matrix_A%delete_matrix()
+    call matrix_B%delete_matrix()
+    call eigenfunctions%delete()
+    call physics%delete()
     call grid%delete()
     call background%delete()
-    call physics%delete()
-    call eigenfunctions%delete()
+    call settings%delete()
   end subroutine cleanup
 
 

--- a/src/settings/mod_io_settings.f08
+++ b/src/settings/mod_io_settings.f08
@@ -93,7 +93,6 @@ contains
 
   pure subroutine set_all_io_to_false(this)
     class(io_settings_t), intent(inout) :: this
-    this%write_matrices = .false.
     this%write_eigenvectors = .false.
     this%write_residuals = .false.
     this%write_eigenfunctions = .false.


### PR DESCRIPTION
## PR description
It seems that #129 introduced a pesky bug if the `dx` spacing function was chosen in such a way that the number of gridpoints increased with respect to the user-set gridpoints, such that these got updated. This change was not propagated correctly to the eigenvalue/eigenvector arrays, which were initialised too early.
This led to the following error, which popped up at completely random times
```
legolas(32399,0x7ff85dcc8340) malloc: 
Incorrect checksum for freed object 0x7f9cb4012400: probably modified after being freed.
Corrupt value: 0x3ff1e376c990c00a
legolas(32399,0x7ff85dcc8340) malloc: *** set a breakpoint in malloc_error_break to debug

Program received signal SIGABRT: Process abort signal.
zsh: abort      ./legolas -i config.par
```

Re-arranging array allocations in the main program so they take place _after_ the grid has been initialised (and thus use the modified number of gridpoints) seems to have fixed the issue.

## Bugfixes
**Legolas**
- Heisenbugfix: malloc error at random intervals when specifying a custom spacing function

