### PR TITLE
Ensure unit tests don't fail silently

### DIFF
--- a/.github/workflows/legolas.yml
+++ b/.github/workflows/legolas.yml
@@ -114,7 +114,11 @@ jobs:
           cmake -DCoverage=ON ..
           make -j 2
           cd ..
-          ./test_legolas
+          # ensure failures are caught, pFUnit sometimes silently fails?
+          ./test_legolas | tee test_legolas.log
+          if grep -q "FAILURES" test_legolas.log; then
+            exit 1
+          fi
         elif [[ "${{ matrix.name }}" == "regression" ]]; then
           cd $LEGOLASDIR/tests/regression_tests
           pytest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,14 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [unit-tests, regression]
+        name: [regression]
         os: [ubuntu-latest]
         compiler: [gfortran-11]
         coverage: [true]
 
     env:
       FC: ${{ matrix.compiler }}
-      PFUNIT_DIR: /home/runner/work/legolas/legolas/tests/pFUnit/build/installed
       LEGOLASDIR: /home/runner/work/legolas/legolas
       ARPACK_ROOT: /home/runner/work/legolas/legolas/tests/arpack-ng
 
@@ -55,25 +54,6 @@ jobs:
         cd post_processing
         python setup.py develop
 
-    - name: Cache pFUnit
-      id: pfunit-cache
-      uses: actions/cache@v1
-      with:
-        path: tests/pFUnit/
-        key: ${{ runner.os }}-pfunitv2
-
-    - name: Build pFUnit
-      if: steps.pfunit-cache.outputs.cache-hit != 'true'
-      run: |
-        cd tests/
-        git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
-        cd pFUnit
-        mkdir build
-        cd build
-        cmake .. -DSKIP_MPI=YES -DSKIP_OPENMP=YES -DSKIP_FHAMCREST=YES
-        make -j 2 tests
-        make -j 2 install
-
     - name: Cache ARPACK
       id: arpack-cache
       uses: actions/cache@v1
@@ -107,22 +87,8 @@ jobs:
 
     - name: Run tests
       run: |
-        if [[ "${{ matrix.name }}" == "unit-tests" ]]; then
-          cd $LEGOLASDIR/tests/unit_tests
-          mkdir build
-          cd build
-          cmake -DCoverage=ON ..
-          make -j 2
-          cd ..
-          # ensure failures are caught, pFUnit sometimes silently fails?
-          ./test_legolas | tee test_legolas.log
-          if grep -q "FAILURES" test_legolas.log; then
-            exit 1
-          fi
-        elif [[ "${{ matrix.name }}" == "regression" ]]; then
-          cd $LEGOLASDIR/tests/regression_tests
-          pytest
-        fi
+        cd $LEGOLASDIR/tests/regression_tests
+        pytest
 
     - name: Generate coverage report
       if: ${{ matrix.coverage }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -13,10 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [unit-tests]
         os: [ubuntu-latest]
-        compiler: [gfortran-11]
-        coverage: [true]
+        compiler: [gfortran-9, gfortran-10, gfortran-12]
+        coverage: [false]
+        include:
+          - os: ubuntu-latest
+            compiler: gfortran-11
+            coverage: true
 
     env:
       FC: ${{ matrix.compiler }}
@@ -24,7 +27,7 @@ jobs:
       LEGOLASDIR: /home/runner/work/legolas/legolas
       ARPACK_ROOT: /home/runner/work/legolas/legolas/tests/arpack-ng
 
-    name: ${{ matrix.name }}
+    name: unit-tests / ${{ matrix.os }} / ${{ matrix.compiler }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
@@ -60,7 +63,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: tests/pFUnit/
-        key: ${{ runner.os }}-pfunitv2
+        key: ${{ runner.os }}-${{ matrix.compiler }}-pfunitv1
 
     - name: Build pFUnit
       if: steps.pfunit-cache.outputs.cache-hit != 'true'
@@ -79,7 +82,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: tests/arpack-ng/
-        key: ${{ runner.os }}-arpackv3
+        key: ${{ runner.os }}-${{ matrix.compiler }}-arpackv1
 
     - name: Build ARPACK
       if: steps.arpack-cache.outputs.cache-hit != 'true'
@@ -125,7 +128,7 @@ jobs:
         mkdir coverage
         cd coverage
         lcov --capture --directory $LEGOLASDIR/build \
-            --output-file ${{ matrix.name }}.info \
+            --output-file unit-tests-${{ matrix.compiler }}.info \
             --gcov-tool /usr/bin/gcov-11
         # filter out coverage files
         find $LEGOLASDIR/build -name '*.gc*' -delete
@@ -141,5 +144,5 @@ jobs:
       uses: codecov/codecov-action@v1
       if: ${{ matrix.coverage }}
       with:
-        files: ./coverage/${{ matrix.name }}.info
+        files: ./coverage/unit-tests-${{ matrix.compiler }}.info
         flags: legolas

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,145 @@
+name: legolas
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [unit-tests]
+        os: [ubuntu-latest]
+        compiler: [gfortran-11]
+        coverage: [true]
+
+    env:
+      FC: ${{ matrix.compiler }}
+      PFUNIT_DIR: /home/runner/work/legolas/legolas/tests/pFUnit/build/installed
+      LEGOLASDIR: /home/runner/work/legolas/legolas
+      ARPACK_ROOT: /home/runner/work/legolas/legolas/tests/arpack-ng
+
+    name: ${{ matrix.name }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install cmake
+      uses: jwlawson/actions-setup-cmake@v1.13.0
+      with:
+        cmake-version: "3.24.x"
+
+    - name: Install Legolas dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install ${{ matrix.compiler }}
+        sudo apt-get install libblas-dev
+        sudo apt-get install liblapack-dev
+        sudo apt-get install lcov
+        ${FC} --version
+        cmake --version
+        gcov --version
+
+    - name: Install Python dependencies & Pylbo
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest numpy matplotlib f90nml tqdm psutil pytest-mpl
+        cd post_processing
+        python setup.py develop
+
+    - name: Cache pFUnit
+      id: pfunit-cache
+      uses: actions/cache@v1
+      with:
+        path: tests/pFUnit/
+        key: ${{ runner.os }}-pfunitv2
+
+    - name: Build pFUnit
+      if: steps.pfunit-cache.outputs.cache-hit != 'true'
+      run: |
+        cd tests/
+        git clone https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+        cd pFUnit
+        mkdir build
+        cd build
+        cmake .. -DSKIP_MPI=YES -DSKIP_OPENMP=YES -DSKIP_FHAMCREST=YES
+        make -j 2 tests
+        make -j 2 install
+
+    - name: Cache ARPACK
+      id: arpack-cache
+      uses: actions/cache@v1
+      with:
+        path: tests/arpack-ng/
+        key: ${{ runner.os }}-arpackv3
+
+    - name: Build ARPACK
+      if: steps.arpack-cache.outputs.cache-hit != 'true'
+      run: |
+        cd tests
+        git clone https://github.com/opencollab/arpack-ng.git
+        cd arpack-ng
+        mkdir build
+        mkdir installed
+        cd build
+        cmake -DEXAMPLES=OFF -DMPI=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=../installed ..
+        make -j 2
+        sudo make -j 2 install
+
+    - name: Compile Legolas
+      run: |
+        mkdir build
+        cd build
+        if [[ "${{ matrix.coverage }}" ]]; then
+          cmake -DCoverage=ON ..
+        else
+          cmake -DDebug=ON ..
+        fi
+        make -j 2
+
+    - name: Run tests
+      run: |
+        cd $LEGOLASDIR/tests/unit_tests
+        mkdir build
+        cd build
+        cmake -DCoverage=ON ..
+        make -j 2
+        cd ..
+        # ensure failures are caught, pFUnit sometimes silently fails?
+        ./test_legolas | tee test_legolas.log
+        if grep -q "FAILURES" test_legolas.log; then
+          exit 1
+        fi
+
+    - name: Generate coverage report
+      if: ${{ matrix.coverage }}
+      run: |
+        mkdir coverage
+        cd coverage
+        lcov --capture --directory $LEGOLASDIR/build \
+            --output-file ${{ matrix.name }}.info \
+            --gcov-tool /usr/bin/gcov-11
+        # filter out coverage files
+        find $LEGOLASDIR/build -name '*.gc*' -delete
+
+    - name: Archive failed logs
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: failed_logs
+        path: tests/regression_tests/test_results
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v1
+      if: ${{ matrix.coverage }}
+      with:
+        files: ./coverage/${{ matrix.name }}.info
+        flags: legolas

--- a/src/solvers/arnoldi/mod_arpack_type.f08
+++ b/src/solvers/arnoldi/mod_arpack_type.f08
@@ -172,6 +172,7 @@ contains
       call logger%error( &
         "Arnoldi: number of eigenvalues must be >= 0 but got " // str(nev) &
       )
+      this%nev = 0
       return
     end if
     if (nev >= this%evpdim) then
@@ -179,6 +180,7 @@ contains
         "Arnoldi: number of eigenvalues (" // str(nev) &
         // ") >= " // "matrix size (" // str(this%evpdim) // ")" &
       )
+      this%nev = 0
       return
     end if
     this%nev = nev

--- a/tests/unit_tests/mod_test_input.pf
+++ b/tests/unit_tests/mod_test_input.pf
@@ -54,7 +54,9 @@ contains
     call read_parfile("test_parfiles/parfile_dryrun.par", settings)
     @assertEqual("none", settings%solvers%get_solver())
     @assertFalse(settings%io%write_eigenfunctions)
-    @assertFalse(settings%io%write_matrices)
+    @assertFalse(settings%io%write_derived_eigenfunctions)
+    @assertFalse(settings%io%write_residuals)
+    @assertTrue(settings%io%write_matrices)
   end subroutine test_parfile_dryrun
 
 

--- a/tests/unit_tests/test_parfiles/parfile_dryrun.par
+++ b/tests/unit_tests/test_parfiles/parfile_dryrun.par
@@ -5,4 +5,5 @@
 &savelist
   write_matrices = .true.
   write_eigenfunctions = .true.
+  write_derived_eigenfunctions = .true.
 /


### PR DESCRIPTION
## PR description
Apparently for some cases when unit tests fail pFUnit flags them as failures in the terminal, but does not properly exit with an error. This affected two minor unit tests which have been silently failing for the past month. This PR ensures a proper exit by piping the terminal output to a log file, grepping for failures and exiting with a 1 status if these are found.

## Bugfixes
**Legolas**
- Fixed two unit tests that were silently failing
- Ensure proper `exit 1` status when the unit testing suite fails

For future reference: Goddard-Fortran-Ecosystem/pFUnit#423

## Testing
**Unit tests**
- Fixed the two failing minor tests
- CI now uses `gcc-9`, `gcc-10`, `gcc-11` and `gcc-12` for unit testing (coverage only with 11)