### PR TITLE
QoL: better logging for user-defined heating

### DIFF
--- a/src/mod_equilibrium.f08
+++ b/src/mod_equilibrium.f08
@@ -236,9 +236,6 @@ contains
     if (settings%physics%cooling%is_enabled()) then
       call physics%heatloss%cooling%initialise()
     end if
-    call physics%heatloss%check_if_thermal_balance_needs_enforcing( &
-      physics%conduction, grid &
-    )
     call physics%hall%validate_scale_ratio(grid%gaussian_grid)
   end subroutine set_equilibrium
 

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -33,8 +33,11 @@ contains
     type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
-    type(physics_t), intent(in) :: physics
+    type(physics_t), intent(inout) :: physics
 
+    call physics%heatloss%check_if_thermal_balance_needs_enforcing( &
+      physics%conduction, grid &
+    )
     if (nan_values_present(background, physics, grid)) return
     if (negative_values_present(background, grid)) return
     if (.not. wave_numbers_are_valid(geometry=settings%grid%get_geometry())) return

--- a/src/mod_version.f08
+++ b/src/mod_version.f08
@@ -14,6 +14,6 @@ module mod_version
   implicit none
 
   !> legolas version number
-  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.2"
+  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.3"
 
 end module mod_version

--- a/src/physics/mod_heatloss.f08
+++ b/src/physics/mod_heatloss.f08
@@ -80,12 +80,16 @@ contains
 
 
   subroutine check_if_thermal_balance_needs_enforcing(this, conduction_tgt, grid_tgt)
+    use mod_function_utils, only: zero_func
+
     class(heatloss_t), intent(inout) :: this
     type(conduction_t), intent(in) :: conduction_tgt
     type(grid_t), intent(in) :: grid_tgt
 
     if (.not. settings%physics%heating%is_enabled()) return
     if (.not. settings%physics%heating%force_thermal_balance) return
+
+    if (.not. associated(this%heating%H, zero_func)) call log_usr_H_func_warning()
 
     call set_module_pointers(conduction_tgt, grid_tgt, this%cooling)
     call logger%info("enforcing thermal balance by setting a constant heating term")
@@ -124,6 +128,21 @@ contains
       + (1.0_dp / settings%physics%get_gamma_1()) * dT0 * rho0 * v01 &
     )
   end function H_for_thermal_balance
+
+
+  subroutine log_usr_H_func_warning() ! LCOV_EXCL_START
+    call logger%warning( &
+      "found user-defined heating function but forced thermal balance enabled!" &
+    )
+    call logger%disable_prefix()
+    call logger%warning( &
+      "The provided function will be ignored and thermal balance will be enforced." &
+    )
+    call logger%warning( &
+      "To disable this behaviour, set force_thermal_balance = .false. in the parfile" &
+    )
+    call logger%enable_prefix()
+  end subroutine log_usr_H_func_warning ! LCOV_EXCL_STOP
 
 
   subroutine delete(this)


### PR DESCRIPTION
## PR description
Minor Quality-of-Life update, Legolas now throws a proper warning if a user-defined heating function is provided while forced thermal balance is enabled. This is done right before the equilibrium balance equations are checked, after info is logged to the console.