### PR TITLE
Ensure proper treatment of pure heating/cooling

### DIFF
--- a/docs/general/parameter_file.md
+++ b/docs/general/parameter_file.md
@@ -58,7 +58,7 @@ This namelist includes all physics-related variables.
 | flow  | logical | inclusion of background flow effects | `.false.` |
 | radiative_cooling | logical | whether to include optically thin radiative losses | `.false.` |
 | ncool | int | number of points used when interpolating cooling curves | 4000 |
-| cooling_curve | string | which cooling curve to use, can be `{"jc_corona", "dalgarno", "dalgarno2", "ml_solar", "spex", "spex_dalgarno", "rosner", "colgan", "colgan_dm"}` | `"jc_corona"` |
+| cooling_curve | string | which cooling curve to use, can be `{"nothing", "jc_corona", "dalgarno", "dalgarno2", "ml_solar", "spex", "spex_dalgarno", "rosner", "colgan", "colgan_dm"}`. In the case of `"nothing"` you should define your own $\Lambda(T)$ cooling function and its temperature derivative. | `"nothing"` |
 | heating | logical | whether to include background heating | `.false.` |
 | force_thermal_balance | logical | whether to set the heating in such a way to enforce thermal equilibrium | `.true.` |
 | external_gravity | logical | whether to include external gravity | `.false.` |

--- a/src/dataIO/mod_input.f08
+++ b/src/dataIO/mod_input.f08
@@ -259,7 +259,8 @@ contains
     if (incompressible) call settings%physics%set_incompressible()
     if (flow) call settings%physics%flow%enable()
     if (radiative_cooling) call settings%physics%enable_cooling(cooling_curve, ncool)
-    if (heating) call settings%physics%enable_heating(force_thermal_balance)
+    settings%physics%heating%force_thermal_balance = force_thermal_balance
+    if (heating) call settings%physics%enable_heating()
     if (external_gravity) call settings%physics%enable_gravity()
     if (parallel_conduction) then
       call settings%physics%enable_parallel_conduction(fixed_tc_para_value)

--- a/src/matrices/mod_matrix_manager.f08
+++ b/src/matrices/mod_matrix_manager.f08
@@ -252,9 +252,7 @@ contains
         do l = 1, dim_quadblock
           idx1 = k + quadblock_idx
           idx2 = l + quadblock_idx
-          call matrix_B%add_element( &
-            row=idx1, column=idx2, element=real(quadblock_B(k, l)) &
-          )
+          call matrix_B%add_element(row=idx1, column=idx2, element=quadblock_B(k, l))
           call matrix_A%add_element(row=idx1, column=idx2, element=quadblock_A(k, l))
         end do
       end do

--- a/src/matrices/mod_matrix_manager.f08
+++ b/src/matrices/mod_matrix_manager.f08
@@ -168,6 +168,17 @@ contains
     integer :: i, j, k, l, idx1, idx2
     integer :: quadblock_idx, gauss_idx, dim_quadblock
 
+    logical :: has_flow, has_resistivity, has_cooling, has_heating, has_conduction
+    logical :: has_viscosity, has_hall
+
+    has_flow = settings%physics%flow%is_enabled()
+    has_resistivity = settings%physics%resistivity%is_enabled()
+    has_cooling = settings%physics%cooling%is_enabled()
+    has_heating = settings%physics%heating%is_enabled()
+    has_conduction = settings%physics%conduction%is_enabled()
+    has_viscosity = settings%physics%viscosity%is_enabled()
+    has_hall = settings%physics%hall%is_enabled()
+
     dim_quadblock = settings%dims%get_dim_quadblock()
     allocate(quadblock_A(dim_quadblock, dim_quadblock))
     allocate(quadblock_B, mold=quadblock_A)
@@ -203,26 +214,22 @@ contains
         call add_regular_matrix_terms( &
           x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
-        if (settings%physics%flow%is_enabled()) call add_flow_matrix_terms( &
+        if (has_flow) call add_flow_matrix_terms( &
           x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
-        if (settings%physics%resistivity%is_enabled()) then
-          call add_resistive_matrix_terms( &
-            x_gauss, weight, quadblock_A, settings, grid, background, physics &
-          )
-        end if
-        if (settings%physics%cooling%is_enabled()) call add_heatloss_matrix_terms( &
+        if (has_resistivity) call add_resistive_matrix_terms( &
           x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
-        if (settings%physics%conduction%is_enabled()) then
-          call add_conduction_matrix_terms( &
-            x_gauss, weight, quadblock_A, settings, grid, background, physics &
-          )
-        end if
-        if (settings%physics%viscosity%is_enabled()) call add_viscosity_matrix_terms( &
+        if (has_cooling .or. has_heating) call add_heatloss_matrix_terms( &
           x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )
-        if (settings%physics%hall%is_enabled()) then
+        if (has_conduction) call add_conduction_matrix_terms( &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
+        )
+        if (has_viscosity) call add_viscosity_matrix_terms( &
+          x_gauss, weight, quadblock_A, settings, grid, background, physics &
+        )
+        if (has_hall) then
           call add_hall_matrix_terms( &
             x_gauss, weight, quadblock_A, settings, grid, background, physics &
         )

--- a/src/mod_version.f08
+++ b/src/mod_version.f08
@@ -14,6 +14,6 @@ module mod_version
   implicit none
 
   !> legolas version number
-  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.3"
+  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.4"
 
 end module mod_version

--- a/src/physics/cooling_curves/mod_cooling_curve_names.f08
+++ b/src/physics/cooling_curves/mod_cooling_curve_names.f08
@@ -4,6 +4,7 @@ module mod_cooling_curve_names
 
   public
 
+  character(len=str_len), parameter :: NOTHING = "nothing"
   character(len=str_len), parameter :: JC_CORONA = "jc_corona"
   character(len=str_len), parameter :: DALGARNO = "dalgarno"
   character(len=str_len), parameter :: DALGARNO2 = "dalgarno2"
@@ -14,8 +15,8 @@ module mod_cooling_curve_names
   character(len=str_len), parameter :: COLGAN = "colgan"
   character(len=str_len), parameter :: COLGAN_DM = "colgan_dm"
 
-  character(len=str_len), parameter :: KNOWN_CURVES(9) = [ &
-    JC_CORONA, DALGARNO, DALGARNO2, ML_SOLAR, SPEX, &
+  character(len=str_len), parameter :: KNOWN_CURVES(10) = [ &
+    NOTHING, JC_CORONA, DALGARNO, DALGARNO2, ML_SOLAR, SPEX, &
     SPEX_DALGARNO, ROSNER, COLGAN, COLGAN_DM &
   ]
 end module mod_cooling_curve_names

--- a/src/physics/mod_physics.f08
+++ b/src/physics/mod_physics.f08
@@ -12,6 +12,7 @@ module mod_physics
   private
 
   type, public :: physics_t
+    type(settings_t), pointer, private :: settings
     type(resistivity_t) :: resistivity
     type(gravity_t) :: gravity
     type(hall_t) :: hall
@@ -36,6 +37,7 @@ contains
     type(background_t), target, intent(in) :: background
     type(physics_t) :: physics
 
+    physics%settings => settings
     physics%resistivity = new_resistivity(settings, background)
     physics%gravity = new_gravity()
     physics%hall = new_hall(settings, background)
@@ -50,6 +52,10 @@ contains
     procedure(real(dp)), optional :: detadT_func
     procedure(real(dp)), optional :: detadr_func
 
+    if (.not. this%settings%physics%resistivity%is_enabled()) then
+      call log_function_warning(name="resistivity")
+      return
+    end if
     this%resistivity%eta => eta_func
     if (present(detadT_func)) this%resistivity%detadT => detadT_func
     if (present(detadr_func)) this%resistivity%detadr => detadr_func
@@ -59,6 +65,11 @@ contains
   subroutine set_gravity_funcs(this, g0_func)
     class(physics_t), intent(inout) :: this
     procedure(real(dp)) :: g0_func
+
+    if (.not. this%settings%physics%gravity%is_enabled()) then
+      call log_function_warning(name="gravity")
+      return
+    end if
     this%gravity%g0 => g0_func
   end subroutine set_gravity_funcs
 
@@ -68,6 +79,10 @@ contains
     procedure(real(dp)) :: tcpara_func
     procedure(real(dp)), optional :: dtcparadT_func
 
+    if (.not. this%settings%physics%conduction%has_parallel_conduction()) then
+      call log_function_warning(name="parallel conduction")
+      return
+    end if
     this%conduction%tcpara => tcpara_func
     if (present(dtcparadT_func)) this%conduction%dtcparadT => dtcparadT_func
   end subroutine set_parallel_conduction_funcs
@@ -82,6 +97,10 @@ contains
     procedure(real(dp)), optional :: dtcperpdrho_func
     procedure(real(dp)), optional :: dtcperpdB2_func
 
+    if (.not. this%settings%physics%conduction%has_perpendicular_conduction()) then
+      call log_function_warning(name="perpendicular conduction")
+      return
+    end if
     this%conduction%tcperp => tcperp_func
     if (present(dtcperpdT_func)) this%conduction%dtcperpdT => dtcperpdT_func
     if (present(dtcperpdrho_func)) this%conduction%dtcperpdrho => dtcperpdrho_func
@@ -94,6 +113,10 @@ contains
     procedure(real(dp)) :: lambdaT_func
     procedure(real(dp)), optional :: dlambdadT_func
 
+    if (.not. this%settings%physics%cooling%is_enabled()) then
+      call log_function_warning(name="cooling")
+      return
+    end if
     this%heatloss%cooling%lambdaT => lambdaT_func
     if (present(dlambdadT_func)) this%heatloss%cooling%dlambdadT => dlambdadT_func
   end subroutine set_cooling_funcs
@@ -105,6 +128,10 @@ contains
     procedure(real(dp)), optional :: dHdT_func
     procedure(real(dp)), optional :: dHdrho_func
 
+    if (.not. this%settings%physics%heating%is_enabled()) then
+      call log_function_warning(name="heating")
+      return
+    end if
     this%heatloss%heating%H => H_func
     if (present(dHdT_func)) this%heatloss%heating%dHdT => dHdT_func
     if (present(dHdrho_func)) this%heatloss%heating%dHdrho => dHdrho_func
@@ -119,5 +146,17 @@ contains
     call this%conduction%delete()
     call this%heatloss%delete
   end subroutine delete
+
+
+  subroutine log_function_warning(name)
+    use mod_logging, only: logger
+    character(len=*), intent(in) :: name
+    call logger%warning( &
+      trim(name) &
+      // " is disabled. User-defined " &
+      // trim(name) &
+      // " function(s) not set." &
+    )
+  end subroutine log_function_warning
 
 end module mod_physics

--- a/src/physics/mod_radiative_cooling.f08
+++ b/src/physics/mod_radiative_cooling.f08
@@ -9,7 +9,7 @@ module mod_radiative_cooling
   use mod_logging, only: logger
   use mod_settings, only: settings_t
   use mod_background, only: background_t
-  use mod_cooling_curve_names, only: ROSNER
+  use mod_cooling_curve_names, only: ROSNER, NOTHING
   implicit none
 
   private
@@ -54,6 +54,8 @@ contains
 
     curve = settings%physics%cooling%get_cooling_curve()
     if (.not. is_valid_cooling_curve(curve)) return
+    if (curve == NOTHING) return
+
     use_interpolated_curve = (curve /= ROSNER)
     deallocate(curve)
 
@@ -71,11 +73,14 @@ contains
     get_lambdaT = 0.0_dp
     if (.not. settings%physics%cooling%is_enabled()) return
 
-    if (settings%physics%cooling%get_cooling_curve() == ROSNER) then
+    select case(settings%physics%cooling%get_cooling_curve())
+    case(NOTHING)
+      return
+    case(ROSNER)
       get_lambdaT = get_rosner_lambdaT(x, settings, background)
-    else
+    case default
       get_lambdaT = get_interpolated_lambdaT(x, settings, background)
-    end if
+    end select
   end function get_lambdaT
 
 
@@ -86,11 +91,14 @@ contains
     get_dlambdadT = 0.0_dp
     if (.not. settings%physics%cooling%is_enabled()) return
 
-    if (settings%physics%cooling%get_cooling_curve() == ROSNER) then
+    select case(settings%physics%cooling%get_cooling_curve())
+    case(NOTHING)
+      return
+    case(ROSNER)
       get_dlambdadT = get_rosner_dlambdadT(x, settings, background)
-    else
+    case default
       get_dlambdadT = get_interpolated_dlambdadT(x, settings, background)
-    end if
+    end select
   end function get_dlambdadT
 
 

--- a/src/physics/mod_solar_atmosphere.f08
+++ b/src/physics/mod_solar_atmosphere.f08
@@ -54,7 +54,7 @@ contains
   subroutine set_solar_atmosphere(settings, background, physics, n_interp)
     use mod_integration, only: integrate_ode_rk45
 
-    type(settings_t), intent(in) :: settings
+    type(settings_t), intent(inout) :: settings
     type(background_t), intent(inout) :: background
     type(physics_t), intent(inout) :: physics
     !> points used for interpolation, defaults to 4000 if not present
@@ -102,6 +102,7 @@ contains
     call background%set_magnetic_2_funcs(B02_func=B02, dB02_func=dB02)
     call background%set_magnetic_3_funcs(B03_func=B03, dB03_func=dB03)
 
+    call settings%physics%enable_gravity()
     call physics%set_gravity_funcs(g0_func=g0)
   end subroutine set_solar_atmosphere
 

--- a/src/settings/mod_physics_settings.f08
+++ b/src/settings/mod_physics_settings.f08
@@ -102,13 +102,13 @@ contains
 
   pure subroutine enable_cooling(this, cooling_curve, interpolation_points)
     class(physics_settings_t), intent(inout) :: this
-    character(len=*), intent(in) :: cooling_curve
+    character(len=*), intent(in), optional :: cooling_curve
     integer, intent(in), optional :: interpolation_points
 
     if (present(interpolation_points)) then
       call this%cooling%set_interpolation_points(interpolation_points)
     end if
-    call this%cooling%set_cooling_curve(cooling_curve)
+    if (present(cooling_curve)) call this%cooling%set_cooling_curve(cooling_curve)
     call this%cooling%enable()
   end subroutine enable_cooling
 

--- a/src/settings/mod_physics_settings.f08
+++ b/src/settings/mod_physics_settings.f08
@@ -116,11 +116,10 @@ contains
   pure subroutine enable_heating(this, force_thermal_balance)
     class(physics_settings_t), intent(inout) :: this
     logical, intent(in), optional :: force_thermal_balance
-    logical :: force_balance
 
-    force_balance = .true.
-    if (present(force_thermal_balance)) force_balance = force_thermal_balance
-    this%heating%force_thermal_balance = force_balance
+    if (present(force_thermal_balance)) then
+      this%heating%force_thermal_balance = force_thermal_balance
+    end if
     call this%heating%enable()
   end subroutine enable_heating
 

--- a/src/settings/physics/mod_cooling_settings.f08
+++ b/src/settings/physics/mod_cooling_settings.f08
@@ -24,10 +24,11 @@ module mod_cooling_settings
 contains
 
   pure function new_cooling_settings() result(cooling)
+    use mod_cooling_curve_names, only: NOTHING
     type(cooling_settings_t) :: cooling
 
     cooling%has_cooling = .false.
-    call cooling%set_cooling_curve("jc_corona")
+    call cooling%set_cooling_curve(NOTHING)
     call cooling%set_interpolation_points(4000)
   end function new_cooling_settings
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -87,6 +87,7 @@ set( test_sources
         mod_test_cooling.pf
         mod_test_cooling_tables.pf
         mod_test_heating.pf
+        mod_test_heatloss.pf
         mod_test_resistivity.pf
         mod_test_conduction.pf
         mod_test_boundaries.pf

--- a/tests/unit_tests/mod_suite_utils.f90
+++ b/tests/unit_tests/mod_suite_utils.f90
@@ -9,6 +9,7 @@ module mod_suite_utils
   implicit none
 
   real(dp), parameter :: TOL = 1.0d-12
+  integer, parameter :: TEST_LOG_LVL = 1
 
 contains
 
@@ -25,7 +26,7 @@ contains
 
     call initialise_globals()
     call init_equilibrium_params()
-    call logger%set_logging_level(1)  ! also print warnings
+    call logger%set_logging_level(TEST_LOG_LVL)  ! also print warnings
     k2 = 1.0d0
     k3 = 2.5d0
   end subroutine reset_globals
@@ -56,6 +57,23 @@ contains
     type(grid_t) :: grid
     grid = new_grid(settings)
   end function get_grid
+
+
+  subroutine get_test_matrices(settings, grid, background, physics, matrix_A, matrix_B)
+    use mod_matrix_structure, only: matrix_t, new_matrix
+    use mod_matrix_manager, only: build_matrices
+
+    type(settings_t), intent(in) :: settings
+    type(grid_t), intent(in) :: grid
+    type(background_t), intent(in) :: background
+    type(physics_t), intent(in) :: physics
+    type(matrix_t), intent(out) :: matrix_A
+    type(matrix_t), intent(out) :: matrix_B
+
+    matrix_A = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="A")
+    matrix_B = new_matrix(nb_rows=settings%dims%get_dim_matrix(), label="B")
+    call build_matrices(matrix_B, matrix_A, settings, grid, background, physics)
+  end subroutine get_test_matrices
 
 
   real(dp) function zero(x)

--- a/tests/unit_tests/mod_test_heating.pf
+++ b/tests/unit_tests/mod_test_heating.pf
@@ -16,6 +16,7 @@ contains
     background = get_background()
     physics = get_physics(settings, background)
     call set_default_units(settings)
+    call settings%physics%enable_heating()
 
     call background%set_density_funcs(rho0_func=rho0_func)
     call background%set_temperature_funcs(T0_func=T0_func, dT0_func=dT0_func)

--- a/tests/unit_tests/mod_test_heatloss.pf
+++ b/tests/unit_tests/mod_test_heatloss.pf
@@ -1,0 +1,202 @@
+module mod_test_heatloss
+  use mod_suite_utils
+  use mod_matrix_structure, only: matrix_t
+  use funit
+  implicit none
+
+  type(settings_t) :: settings
+  type(physics_t) :: physics
+  type(background_t) :: background
+  type(grid_t) :: grid
+  type(matrix_t) :: matrix_A, matrix_B
+  complex(dp), allocatable :: eigenvals(:)
+
+  character(len=*), parameter :: msg_heatloss_balance = ( &
+    "forced thermal balance needs cooling + heating. " // &
+    "Set 'force_thermal_balance = .false.' in the parfile or enable heating/cooling" &
+  )
+
+contains
+
+  @before
+  subroutine init_test()
+    settings = get_settings()
+    background = get_background()
+    physics = get_physics(settings, background)
+    grid = create_test_grid( &
+      settings, pts=25, geometry="Cartesian", grid_start=0.0_dp, grid_end=1.0_dp &
+    )
+    settings%io%write_eigenfunctions = .false.
+    call settings%solvers%set_solver("QR-cholesky")
+    allocate( &
+      eigenvals(settings%dims%get_dim_matrix()), source=cmplx(1.0_dp, 3.0_dp, kind=dp) &
+    )
+    call logger%set_logging_level(0)
+  end subroutine init_test
+
+
+  @after
+  subroutine teardown_test()
+    call settings%delete()
+    call background%delete()
+    call physics%delete()
+    call grid%delete()
+    call matrix_A%delete_matrix()
+    call matrix_B%delete_matrix()
+    if (allocated(eigenvals)) deallocate(eigenvals)
+    call logger%set_logging_level(TEST_LOG_LVL)
+  end subroutine teardown_test
+
+
+  subroutine set_background()
+    use mod_equilibrium_params, only: k2, k3
+
+    k2 = 0.0_dp
+    k3 = 3.0_dp
+    call background%set_density_funcs(rho0_func=one)
+    call background%set_temperature_funcs(T0_func=one)
+    call background%set_magnetic_3_funcs(B03_func=one)
+    call physics%set_cooling_funcs(lambdaT_func=lambdaT_cte)
+    call physics%set_heating_funcs(H_func=heating_cte)
+  end subroutine set_background
+
+
+  subroutine enable_cooling()
+    call settings%physics%enable_cooling()
+  end subroutine enable_cooling
+
+
+  subroutine enable_heating(force_balance)
+    logical, intent(in) :: force_balance
+    call settings%physics%enable_heating(force_thermal_balance=force_balance)
+  end subroutine enable_heating
+
+
+  subroutine assemble_and_solve()
+    use mod_solvers, only: solve_evp
+    complex(dp) :: right_eigenvecs(2, 2)
+
+    call set_background()
+    call physics%heatloss%check_if_thermal_balance_needs_enforcing( &
+      physics%conduction, grid &
+    )
+    call get_test_matrices(settings, grid, background, physics, matrix_A, matrix_B)
+    call solve_evp(matrix_A, matrix_B, settings, eigenvals, right_eigenvecs)
+  end subroutine assemble_and_solve
+
+
+  logical function eigenvals_all_real()
+    use mod_check_values, only: is_zero
+    eigenvals_all_real = all(is_zero(aimag(eigenvals), tol=TOL))
+  end function eigenvals_all_real
+
+
+  real(dp) function lambdaT_cte()
+    lambdaT_cte = 1.5_dp
+  end function lambdaT_cte
+
+
+  real(dp) function heating_cte()
+    heating_cte = 4.3_dp
+  end function heating_cte
+
+
+  function get_actual_lambdaT() result(lambdaT)
+    real(dp) :: lambdaT(size(grid%gaussian_grid))
+    lambdaT = physics%heatloss%cooling%lambdaT(grid%gaussian_grid)
+  end function get_actual_lambdaT
+
+
+  function get_actual_H0() result(H0)
+    real(dp) :: H0(size(grid%gaussian_grid))
+    H0 = physics%heatloss%heating%H(grid%gaussian_grid)
+  end function get_actual_H0
+
+
+  @test
+  subroutine test_adiabatic_reference_run()
+    call set_name("heatloss: adiabatic reference run")
+    call assemble_and_solve()
+    @assertFalse(settings%physics%heating%is_enabled())
+    @assertFalse(settings%physics%cooling%is_enabled())
+    @assertEqual(0.0_dp, get_actual_lambdaT(), tolerance=TOL)
+    @assertEqual(0.0_dp, get_actual_H0(), tolerance=TOL)
+    @assertTrue(eigenvals_all_real())
+  end subroutine test_adiabatic_reference_run
+
+
+
+  @test
+  subroutine test_Q_H_force_balance()
+    call set_name("heatloss: heating + cooling, force thermal balance")
+    call enable_cooling()
+    call enable_heating(force_balance=.true.)
+    call assemble_and_solve()
+    ! heating overridden through forced thermal balance, rho = 1 so H0 = lambdaT
+    @assertEqual(lambdaT_cte(), get_actual_lambdaT(), tolerance=TOL)
+    @assertEqual(lambdaT_cte(), get_actual_H0(), tolerance=TOL)
+    @assertTrue(settings%physics%heating%force_thermal_balance)
+    @assertFalse(eigenvals_all_real())
+  end subroutine test_Q_H_force_balance
+
+
+  @test
+  subroutine test_Q_H()
+    call set_name("heatloss: unbalanced heating + cooling")
+    call enable_cooling()
+    call enable_heating(force_balance=.false.)
+    call assemble_and_solve()
+    @assertEqual(lambdaT_cte(), get_actual_lambdaT(), tolerance=TOL)
+    @assertEqual(heating_cte(), get_actual_H0(), tolerance=TOL)
+    @assertFalse(settings%physics%heating%force_thermal_balance)
+    @assertFalse(eigenvals_all_real())
+  end subroutine test_Q_H
+
+
+
+  @test
+  subroutine test_Q_only_force_balance()
+    call set_name("heatloss: only cooling, force thermal balance")
+    call enable_cooling()
+    settings%physics%heating%force_thermal_balance = .true.
+    call assemble_and_solve()
+    @assertExceptionRaised(msg_heatloss_balance)
+  end subroutine test_Q_only_force_balance
+
+
+  @test
+  subroutine test_Q_only()
+    call set_name("heatloss: only cooling")
+    call enable_cooling()
+    settings%physics%heating%force_thermal_balance = .false.
+    call assemble_and_solve()
+    @assertFalse(settings%physics%heating%is_enabled())
+    @assertEqual(lambdaT_cte(), get_actual_lambdaT(), tolerance=TOL)
+    @assertEqual(0.0_dp, get_actual_H0(), tolerance=TOL)
+    @assertFalse(eigenvals_all_real())
+  end subroutine test_Q_only
+
+
+
+  @test
+  subroutine test_H_only_force_balance()
+    call set_name("heatloss: only heating, force thermal balance")
+    call enable_heating(force_balance=.true.)
+    call assemble_and_solve()
+    @assertExceptionRaised(msg_heatloss_balance)
+  end subroutine test_H_only_force_balance
+
+
+  @test
+  subroutine test_H_only()
+    call set_name("heatloss: only heating")
+    call enable_heating(force_balance=.false.)
+    call assemble_and_solve()
+    @assertTrue(settings%physics%heating%is_enabled())
+    @assertFalse(settings%physics%cooling%is_enabled())
+    @assertEqual(0.0_dp, get_actual_lambdaT(), tolerance=TOL)
+    @assertEqual(heating_cte(), get_actual_H0(), tolerance=TOL)
+    @assertFalse(eigenvals_all_real())
+  end subroutine test_H_only
+
+end module mod_test_heatloss

--- a/tests/unit_tests/mod_test_heatloss.pf
+++ b/tests/unit_tests/mod_test_heatloss.pf
@@ -1,6 +1,7 @@
 module mod_test_heatloss
   use mod_suite_utils
   use mod_matrix_structure, only: matrix_t
+  use mod_heatloss, only: msg_heatloss_balance
   use funit
   implicit none
 
@@ -10,11 +11,6 @@ module mod_test_heatloss
   type(grid_t) :: grid
   type(matrix_t) :: matrix_A, matrix_B
   complex(dp), allocatable :: eigenvals(:)
-
-  character(len=*), parameter :: msg_heatloss_balance = ( &
-    "forced thermal balance needs cooling + heating. " // &
-    "Set 'force_thermal_balance = .false.' in the parfile or enable heating/cooling" &
-  )
 
 contains
 
@@ -183,7 +179,13 @@ contains
     call set_name("heatloss: only heating, force thermal balance")
     call enable_heating(force_balance=.true.)
     call assemble_and_solve()
-    @assertExceptionRaised(msg_heatloss_balance)
+    @assertTrue(settings%physics%heating%is_enabled())
+    @assertFalse(settings%physics%cooling%is_enabled())
+    @assertEqual(0.0_dp, get_actual_lambdaT(), tolerance=TOL)
+    ! heating overridden through forced thermal balance, rho = 1 so H0 = lambdaT = 0
+    @assertEqual(0.0_dp, get_actual_H0(), tolerance=TOL)
+    @assertTrue(settings%physics%heating%force_thermal_balance)
+    @assertTrue(eigenvals_all_real())
   end subroutine test_H_only_force_balance
 
 

--- a/tests/unit_tests/mod_test_inspections.pf
+++ b/tests/unit_tests/mod_test_inspections.pf
@@ -146,6 +146,7 @@ contains
   @test
   subroutine test_gravity_nan()
     call set_name("gravity NaN")
+    call settings%physics%enable_gravity()
     call physics%set_gravity_funcs(g0_func=g0)
     call do_checks()
     @assertExceptionRaised("NaN encountered in gravity")


### PR DESCRIPTION
## PR description
This PR ensures that pure heating and/or cooling through custom-defined functions behaves as expected.
In short:
- Ensures that heating without cooling is checked when adding non-adiabatic matrix elements; this was not the case previously.
- The default cooling curve is now `"nothing"` (docs have been updated), to prevent unnecessary table initialisations and interpolations for cases in which a custom cooling function is provided.
- Prevents setting custom functions when the corresponding physical effect is not enabled.
- Throw an error if thermal balance is enforced but heating is disabled.
- Sanity checks are now in place when treating forced thermal balance.
- New unit tests for these particular cases are now in place.

## Bugfixes
**Legolas**
- Fixes #144 
