### PR TITLE
Hotfix: linking issue with `zggev3`

### DIFF
--- a/src/mod_version.f08
+++ b/src/mod_version.f08
@@ -14,6 +14,6 @@ module mod_version
   implicit none
 
   !> legolas version number
-  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.5"
+  character(len=10), parameter    :: LEGOLAS_VERSION = "2.0.6"
 
 end module mod_version

--- a/src/solvers/smod_qz_direct.f08
+++ b/src/solvers/smod_qz_direct.f08
@@ -61,7 +61,7 @@ contains
     allocate(rwork(8 * N))
     ! get lwork
     allocate(work(1))
-    call zggev3( &
+    call zggev( &
       jobvl, jobvr, N, array_A, lda, array_B, ldb, &
       alpha, beta, vl, ldvl, vr, ldvr, work, -1, rwork, info &
     )
@@ -72,7 +72,7 @@ contains
 
     ! solve eigenvalue problem
     call logger%debug("solving evp using QZ algorithm zggev (LAPACK)")
-    call zggev3( &
+    call zggev( &
       jobvl, jobvr, N, array_A, lda, array_B, ldb, &
       alpha, beta, vl, ldvl, vr, ldvr, work, lwork, rwork, info &
     )


### PR DESCRIPTION
## PR description
Fixes the linking issue with `zggev3` as explained in #148. Was not able to reproduce the issue and eventually decided to simply switch to the standard `zggev` routine instead of the previously used block variant. The QZ solver is barely used and is slower than the others anyway, so possible performance loss doesn't really matter here.

## Bugfixes
**Legolas**
- Switched from `zggev3` to `zggev` LAPACK routines to solve using QZ.
    - Fixes #148 