### PR TITLE
Fix deprecation warnings due to NumPy 1.25 and Matplotlib 3.7

### DIFF
--- a/post_processing/pylbo/visualisation/continua.py
+++ b/post_processing/pylbo/visualisation/continua.py
@@ -274,13 +274,14 @@ def _extract_solutions_from_roots(
     if np.count_nonzero(mask) == 1:
         # if mask only has one True, it is the thermal continuum and others are slow
         ws_neg, ws_pos = np.sort_complex(roots[np.invert(mask)])
-        return ws_neg, ws_pos, roots[mask]
+        (thermal,) = roots[mask]
+        return ws_neg, ws_pos, thermal
     _log_slow_continuum_zero_warning(roots, i)
     # here we have multiple purely imaginary roots, so it's not clear which one
     # is the thermal continuum. We assume that it is the largest one.
     mask = np.array([False] * 3, dtype=bool)
     mask[roots.imag.argmax()] = True
-    thermal = roots[mask]
+    (thermal,) = roots[mask]
     _log_assumed_thermal_continuum(root=thermal)
     ws_neg, ws_pos = np.sort_complex(roots[np.invert(mask)])
     return ws_neg, ws_pos, thermal

--- a/post_processing/pylbo/visualisation/figure_window.py
+++ b/post_processing/pylbo/visualisation/figure_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import matplotlib.gridspec as gridspec
@@ -90,6 +91,22 @@ class FigureWindow:
         occurences = sum(figlabel in fig_id for fig_id in self.figure_ids)
         return f"{figlabel}-{1 + occurences}"
 
+    def make_layout_tight(self) -> None:
+        """
+        Calls tight_layout() on a figure and captures the userwarning introduced
+        in matplotlib 3.5.
+        """
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.fig.tight_layout()
+            for warning in w:
+                msg = warning.message
+                if not (isinstance(msg, UserWarning) and "tight" in str(msg)):
+                    pylboLogger.warning(
+                        f"{warning.filename}:{warning.lineno}: "
+                        f"{warning.category.__name__}: {msg}"
+                    )
+
     def add_to_stack(self) -> None:
         """
         Adds the figure to the stack.
@@ -164,7 +181,7 @@ class FigureWindow:
             gspec_inner[old_new_position[1]], sharex=sharex, sharey=sharey
         )
         if apply_tight_layout:
-            self.fig.tight_layout()
+            self.make_layout_tight()
         return new_axis
 
     def draw(self) -> None:

--- a/post_processing/pylbo/visualisation/legend_handler.py
+++ b/post_processing/pylbo/visualisation/legend_handler.py
@@ -2,7 +2,27 @@ import matplotlib.collections as mpl_collections
 import matplotlib.lines as mpl_lines
 import matplotlib.patches as mpl_patches
 import numpy as np
+from pylbo._version import _mpl_version
 from pylbo.utilities.toolbox import add_pickradius_to_item
+
+
+def _get_legend_handles(legend):
+    """
+    Returns the legend handles.
+
+    Parameters
+    ----------
+    legend : ~matplotlib.legend.Legend
+        The matplotlib legend to use.
+
+    Returns
+    -------
+    handles : list
+        A list of handles.
+    """
+    if _mpl_version >= "3.7":
+        return legend.legend_handles
+    return legend.legendHandles
 
 
 class LegendHandler:
@@ -76,22 +96,21 @@ class LegendHandler:
         else:
             artist.set_alpha(self.alpha_hidden)
         self._check_autoscaling()
-        artist.figure.tight_layout()
         artist.figure.canvas.draw()
 
     def make_legend_pickable(self):
         """Makes the legend pickable, only used if interactive."""
-        legend_handles = self.legend.legendHandles
+        legend_handles = _get_legend_handles(self.legend)
         handle_labels = [handle.get_label() for handle in legend_handles]
         # we need a mapping of the legend item to the actual item that was drawn
         for i, drawn_item in enumerate(self._drawn_items):
             # try-except needed for fill_between, which returns empty handles
             try:
                 idx = handle_labels.index(drawn_item.get_label())
-                legend_item = self.legend.legendHandles[idx]
+                legend_item = _get_legend_handles(self.legend)[idx]
             except ValueError:
                 idx = i
-                legend_item = self.legend.legendHandles[idx]
+                legend_item = _get_legend_handles(self.legend)[idx]
                 # fix empty label
                 legend_item.set_label(drawn_item.get_label())
             add_pickradius_to_item(item=legend_item, pickradius=self.pickradius)

--- a/post_processing/pylbo/visualisation/profiles.py
+++ b/post_processing/pylbo/visualisation/profiles.py
@@ -33,7 +33,7 @@ class EquilibriumProfile(InteractiveFigureWindow):
         self._figure_drawn = True
         if interactive:
             super().make_legend_interactive(self.leg_handle)
-        self.fig.tight_layout()
+        self.make_layout_tight()
 
     def draw(self):
         """Adds the equilibria to the figure. Also sets the legend handler items"""
@@ -98,7 +98,7 @@ class ContinuumProfile(InteractiveFigureWindow):
         self._figure_drawn = True
         if interactive:
             self.make_legend_interactive(self.handler)
-        self.fig.tight_layout()
+        self.make_layout_tight()
 
     def draw(self):
         """Adds the continua to the plot, also sets the legend handlers."""
@@ -160,7 +160,7 @@ class EquilibriumBalance(InteractiveFigureWindow):
         self._figure_drawn = True
         if interactive:
             self.make_legend_interactive(self.legend_handler)
-        self.fig.tight_layout()
+        self.make_layout_tight()
 
     def draw(self):
         """Draws the equilibrium balance equations."""

--- a/tests/pylbo_tests/test_ef_interface.py
+++ b/tests/pylbo_tests/test_ef_interface.py
@@ -7,6 +7,7 @@ import numpy as np
 import pylbo
 from pylbo.testing import MockKeyEvent, MockPickEvent
 from pylbo.utilities.logger import pylboLogger
+from pylbo.visualisation.legend_handler import _get_legend_handles
 
 MODE1 = 0.1 + 0.62j
 MODE2 = 0.1 + 0.58j
@@ -180,7 +181,7 @@ def test_ef_click_on_legend_item(ds_v200_mri_efs):
     p.add_continua()
     event = _create_mockpickevent(p, x=0.1, y=0.62, button=1)
     # set artist equal to clickable first legend item instead of datapoints
-    event.artist = p.ef_handler.spec_axis.get_legend().legendHandles[0]
+    event.artist = _get_legend_handles(p.ef_handler.spec_axis.get_legend())[0]
     p.ef_handler.on_point_pick(event)
     # should do nothing
     assert p.ef_handler.get_selected_idxs() == {}
@@ -203,7 +204,7 @@ def test_ef_get_artist_data(ds_v200_mri_efs):
 
     p = _create_ef_spectrum_plot(ds_v200_mri_efs)
     p.add_continua()
-    artist = p.ef_handler.spec_axis.get_legend().legendHandles[0]
+    artist = _get_legend_handles(p.ef_handler.spec_axis.get_legend())[0]
     xdata, ydata = get_artist_data(artist)
     assert isinstance(xdata, np.ndarray)
     assert xdata.ndim == 1

--- a/tests/pylbo_tests/test_legend_handler.py
+++ b/tests/pylbo_tests/test_legend_handler.py
@@ -1,6 +1,7 @@
 import matplotlib as mpl
 import pylbo
 from pylbo.testing import MockPickEvent
+from pylbo.visualisation.legend_handler import _get_legend_handles
 
 
 def _create_profile_plot(ds):
@@ -8,7 +9,7 @@ def _create_profile_plot(ds):
 
 
 def get_legend_artists(ax):
-    return ax.get_legend().legendHandles
+    return _get_legend_handles(ax.get_legend())
 
 
 def get_children(ax, artists=None):


### PR DESCRIPTION
## PR description
Various deprecation warnings were introduced by the new numpy 1.25 and matplotlib 3.7 versions, here we make some small tweaks to fix them.

Warnings that were fixed:
- `DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`
- `MatplotlibDeprecationWarning: The legendHandles attribute was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use legend_handles instead.`
- `UserWarning: The figure layout has changed to tight`
  This one needed special attention, we actually want this behaviour to ensure the interactive legend isn't clipped by the  
  figure boundaries. This (and only this) UserWarning is now suppressed and `tight_layout()` is still applied.
