### PR TITLE
Enable gfortran13 for unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        compiler: [gfortran-9, gfortran-10, gfortran-12]
+        compiler: [gfortran-9, gfortran-10, gfortran-12, gfortran-13]
         coverage: [false]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
## PR description
Adds `gfortran-13` to the CI pipeline for unit tests.
