### PR TITLE
dp_limit and small matrix elements

### DIFF
--- a/post_processing/pylbo/utilities/toolbox.py
+++ b/post_processing/pylbo/utilities/toolbox.py
@@ -282,13 +282,7 @@ def solve_cubic_exact(a, b, c, d):
         - 27 * r
         + 3
         * np.sqrt(3)
-        * np.sqrt(
-            -(p**2) * q**2
-            + 4 * q**3
-            + 4 * p**3 * r
-            - 18 * p * q * r
-            + 27 * r**2
-        )
+        * np.sqrt(-(p**2) * q**2 + 4 * q**3 + 4 * p**3 * r - 18 * p * q * r + 27 * r**2)
     ) ** (1 / 3) / (3 * 2 ** (1 / 3))
     Bterm = (-(p**2) + 3 * q) / (9 * Aterm)
     cterm_min = (-1 - np.sqrt(3) * 1j) / 2

--- a/src/equilibria/smod_equil_coronal_flux_tube.f08
+++ b/src/equilibria/smod_equil_coronal_flux_tube.f08
@@ -106,7 +106,7 @@ contains
       gamma * cte_p0 * (2.0_dp * gamma + 1.0_dp) / (50.0_dp * gamma + 1.0_dp) &
     )
     ! check pressure balance
-    if (abs(cte_p0 + 0.5_dp * B_0**2 - p_e - 0.5_dp * B_e**2) > dp_LIMIT) then
+    if (abs(cte_p0 + 0.5_dp * B_0**2 - p_e - 0.5_dp * B_e**2) > 10.0_dp*dp_LIMIT) then
       call logger%error("equilibrium: total pressure balance not satisfied")
     end if
 

--- a/src/equilibria/smod_equil_photospheric_flux_tube.f08
+++ b/src/equilibria/smod_equil_photospheric_flux_tube.f08
@@ -105,7 +105,7 @@ contains
     B_0 = 2.0_dp * sqrt(gamma * cte_p0)
     B_e = sqrt(2.0_dp * gamma * cte_p0 * (2.0_dp * gamma + 1.0_dp) / (gamma + 18.0_dp))
     ! check pressure balance
-    if (abs(cte_p0 + 0.5_dp * B_0**2 - p_e - 0.5_dp * B_e**2) > dp_LIMIT) then
+    if (abs(cte_p0 + 0.5_dp * B_0**2 - p_e - 0.5_dp * B_e**2) > 10.0_dp*dp_LIMIT) then
       call logger%error("equilibrium: total pressure balance not satisfied")
     end if
 

--- a/src/matrices/datastructure/mod_matrix_node.f08
+++ b/src/matrices/datastructure/mod_matrix_node.f08
@@ -64,6 +64,7 @@ contains
   !> Adds a given element to the node element, does type-checking of the polymorphic
   !! element given. Allowed types are complex, real, integer.
   subroutine add_to_node_element(this, element)
+    use mod_check_values, only: is_zero
     !> type instance
     class(node_t), intent(inout) :: this
     !> element to add to the existing element
@@ -77,6 +78,9 @@ contains
       type is (integer)
         this%element = this%element + cmplx(element, kind=dp)
     end select
+
+    if (is_zero(this%element)) this%element = cmplx(0.0d0, kind=dp)
+
   end subroutine add_to_node_element
 
 

--- a/src/matrices/datastructure/mod_matrix_structure.f08
+++ b/src/matrices/datastructure/mod_matrix_structure.f08
@@ -134,7 +134,7 @@ contains
 
   !> Returns the complex element associated with the linked-list node at position
   !! (row, column) in the matrix datastructure. Non-existing nodes correspond to zero
-  !! values, so when a node at (row, column) is not foudn this function returns
+  !! values, so when a node at (row, column) is not found this function returns
   !! (complex) zero.
   function get_complex_element(this, row, column) result(element)
     !> type instance

--- a/src/mod_global_variables.f08
+++ b/src/mod_global_variables.f08
@@ -16,7 +16,7 @@ module mod_global_variables
   integer, parameter :: str_len_arr = 16
 
   !> tolerance for real(dp) zero, bit higher than machine precision
-  real(dp), parameter :: dp_LIMIT = 5.0d-15
+  real(dp), parameter :: dp_LIMIT = 5.0d-16
   !> NaN value (ieee_quiet_nan)
   real(dp), protected :: NaN
 

--- a/src/mod_inspections.f08
+++ b/src/mod_inspections.f08
@@ -184,35 +184,38 @@ contains
 
   subroutine validate_equilibrium_conditions(settings, grid, background, physics)
     use mod_check_values, only: is_zero
+    use mod_global_variables, only: dp_limit
     type(settings_t), intent(in) :: settings
     type(grid_t), intent(in) :: grid
     type(background_t), intent(in) :: background
     type(physics_t), intent(in) :: physics
     real(dp) :: values(size(grid%gaussian_grid))
+    real(dp) :: tol
 
+    tol = 10.0_dp * dp_limit
     values = 0.0_dp
     ! continuity equation
     values = continuity_condition(grid%gaussian_grid, grid, background)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("continuity equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
     end if
     ! force balance
     values = force_balance_1_condition(grid%gaussian_grid, grid, background, physics)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("force balance 1 equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
     end if
     values = force_balance_2_condition(grid%gaussian_grid, grid, background)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("force balance 2 equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
     end if
     values = force_balance_3_condition(grid%gaussian_grid, background)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("force balance 3 equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
@@ -221,20 +224,20 @@ contains
     values = energy_balance_condition( &
       grid%gaussian_grid, settings, grid, background, physics &
     )
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("energy balance equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
     end if
     ! induction equation
     values = induction_1_condition(grid%gaussian_grid, background)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("induction 1 equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))
     end if
     values = induction_2_condition(grid%gaussian_grid, grid, background)
-    if (.not. all(is_zero(values))) then
+    if (.not. all(is_zero(values, tol))) then
       call logger%warning("induction 2 equation not satisfied!")
       call logger%warning("location of largest discrepancy: x = " // str(getx()))
       call logger%warning("value: " // str(getval(), fmt=exp_fmt))

--- a/tests/pylbo_tests/test_dataseries.py
+++ b/tests/pylbo_tests/test_dataseries.py
@@ -33,7 +33,7 @@ def test_series_has_efs(series_v112):
 
 
 def test_series_ef_names_not_present(series_v100):
-    assert np.all(series_v100.ef_names) is None
+    assert np.all(series_v100.ef_names == [None] * len(series_v100))
 
 
 def test_series_ef_names(series_v112):

--- a/tests/pylbo_tests/test_dataset.py
+++ b/tests/pylbo_tests/test_dataset.py
@@ -169,7 +169,7 @@ def test_ds_get_efs_guess_single(ds_v112):
     efs = ds_v112.get_eigenfunctions(ev_guesses=guess)
     assert isinstance(efs, np.ndarray)
     (ef,) = efs
-    assert np.isclose(guess, ef.get("eigenvalue", np.NaN))
+    assert np.isclose(guess, ef.get("eigenvalue", np.nan))
 
 
 def test_ds_get_efs_guess_list(ds_v112):
@@ -177,21 +177,21 @@ def test_ds_get_efs_guess_list(ds_v112):
     efs = ds_v112.get_eigenfunctions(ev_guesses=guess)
     assert isinstance(efs, np.ndarray)
     for i, ef in enumerate(efs):
-        assert np.isclose(guess[i], ef.get("eigenvalue", np.NaN))
+        assert np.isclose(guess[i], ef.get("eigenvalue", np.nan))
 
 
 def test_ds_get_efs_idx(ds_v112):
     efs = ds_v112.get_eigenfunctions(ev_idxs=ds_v112_ev_idx)
     assert isinstance(efs, np.ndarray)
     (ef,) = efs
-    assert np.isclose(ds_v112_ev_guess, ef.get("eigenvalue", np.NaN))
+    assert np.isclose(ds_v112_ev_guess, ef.get("eigenvalue", np.nan))
 
 
 def test_ds_get_efs_idx_list(ds_v112):
     efs = ds_v112.get_eigenfunctions(ev_idxs=[ds_v112_ev_idx] * 2)
     assert isinstance(efs, np.ndarray)
     for ef in efs:
-        assert np.isclose(ds_v112_ev_guess, ef.get("eigenvalue", np.NaN))
+        assert np.isclose(ds_v112_ev_guess, ef.get("eigenvalue", np.nan))
 
 
 def test_ds_get_evs(ds_v112):


### PR DESCRIPTION
## PR description
The dp_limit that determines the tolerance for near-zero numbers has been lowered to 5e-16, which improves the numerical stability of some equilibria and produces less spurious modes. Additionally, matrix elements are now explicitly set to zero is they are below this limit, which can occur when two equal but opposite numbers get added in a matrix element.

## Bugfixes
**Legolas**
Issues with the `gravito_acoustic`, `gravito_mhd` and `interchange_modes` spectra for resolution higher than 50 have now been resolved.

## Checklist
- [x] all tests pass (and for new features, new tests are added)
- [x] documentation has been updated (if applicable)
