### PR TITLE
IVP module improvements

### DIFF
--- a/docs/general/initial_value.md
+++ b/docs/general/initial_value.md
@@ -20,13 +20,21 @@ This page assumes familiarity with how to set up and run Legolas. If not, see [r
 
 ## Supported physics types
 
-The initial-value solver currently supports:
+The initial-value solver supports the same physics types as the eigenvalue solver:
 
 | Physics type | Perturbed components |
 |---|---|
 | `isothermal-1d` | $\rho_1$, $v_1$ |
 | `hd-1d` | $\rho_1$, $v_1$, $T_1$ |
 | `hd` | $\rho_1$, $v_1$, $v_2$, $v_3$, $T_1$ |
+| `mhd` | $\rho_1$, $v_1$, $v_2$, $v_3$, $T_1$, $a_1$, $a_2$, $a_3$ |
+
+The physics type is set in the parfile (not in the Fortran submodule):
+```fortran
+&physicslist
+  physics_type = "isothermal-1d"
+/
+```
 
 ## Configuration
 
@@ -45,20 +53,40 @@ IVP mode is configured through the `ivplist` namelist in the parfile:
 
 Snapshots are written to the datfile automatically when `enabled = .true.`.
 
-## Specifying initial conditions
+### Skipping the eigenvalue solve
 
-Initial conditions are set in the `user_defined_eq` subroutine of your `smod_user_defined.f08` file.
-An `initial_conditions` object is passed in alongside the standard `settings`, `grid`, `background`, and `physics` objects.
-You set perturbation profiles using type-bound setter routines — each takes a function (and optionally its derivative) matching the signature `f(x) result(y)` where `x` and `y` are both `real(dp)` arrays of the same size.
+The initial-value solver assembles and uses the same `A` and `B` matrices as the eigenvalue
+solver, but it does **not** require the (potentially expensive) eigenvalue problem to be solved
+first. If you only want the time evolution, select the `"none"` solver to bypass the eigenvalue
+solve entirely:
 
-The physics type must be set in the parfile (not in the Fortran submodule):
 ```fortran
-&physicslist
-  physics_type = "isothermal-1d"
+&solvelist
+  solver = "none"
 /
 ```
 
-A minimal example with a Gaussian density perturbation:
+The datfile then contains the IVP snapshots but no eigenvalues or eigenfunctions: selecting
+`"none"` also switches off eigenfunction, eigenvector and residual output, since these are
+meaningless without eigenvalues. IVP snapshot output is unaffected.
+See the [solver settings](../../general/solvers) for more details.
+
+## Specifying initial conditions
+
+Initial conditions are set in the `user_defined_eq` procedure of your `smod_user_defined.f08` file,
+exactly like a regular equilibrium (see [implementing a custom setup](../../general/own_setup)).
+Alongside the standard `settings`, `grid`, `background`, and `physics` objects, the procedure receives
+an `iv_initial_conditions` object (of type `initial_conditions_t`) through host association from the
+parent module — you do not need to declare it yourself when using `module procedure`.
+
+You set the perturbation profiles with the type-bound setter routines on `iv_initial_conditions`.
+Each setter takes a profile function (and optionally its derivative) matching the interface
+`f(x) result(y)`, where `x` and `y` are both `real(dp)` arrays of the same size. This is the same
+signature used by the initial-value profiles, and differs from the scalar-valued `background`
+functions.
+
+A minimal example with a Gaussian density perturbation on a uniform isothermal background
+(this mirrors the bundled `ivp_demo` equilibrium):
 
 ```fortran
 submodule (mod_equilibrium) smod_user_defined
@@ -66,35 +94,30 @@ submodule (mod_equilibrium) smod_user_defined
 
 contains
 
-  module subroutine user_defined_eq(settings, grid, background, physics, initial_conditions)
-    type(settings_t), intent(inout)           :: settings
-    type(grid_t), intent(inout)               :: grid
-    type(background_t), intent(inout)         :: background
-    type(physics_t), intent(inout)            :: physics
-    type(initial_conditions_t), intent(inout) :: initial_conditions
+  module procedure user_defined_eq
+    call settings%grid%set_geometry("Cartesian")
+    call settings%grid%set_grid_boundaries(0.0_dp, 1.0_dp)
 
-    ! --- equilibrium ---
-    background%density%rho0   => uniform_density
-    background%temperature%T0 => uniform_temperature
+    ! --- background equilibrium (scalar-valued functions) ---
+    call background%set_density_funcs(rho0_func=rho0)
+    call background%set_temperature_funcs(T0_func=T0)
 
-    ! --- initial conditions ---
-    call initial_conditions%set_ic_density_funcs(rho_func=gaussian_rho)
-
-  end subroutine user_defined_eq
+    ! --- initial conditions (array-valued profile functions) ---
+    call iv_initial_conditions%set_ic_density_funcs( &
+      rho_func=gaussian_rho, drho_func=gaussian_drho &
+    )
+  end procedure user_defined_eq
 
 
-  pure function uniform_density(x) result(rho)
-    real(dp), intent(in) :: x(:)
-    real(dp) :: rho(size(x))
-    rho = 1.0_dp
-  end function uniform_density
+  real(dp) function rho0()
+    rho0 = 1.0_dp
+  end function rho0
 
-  pure function uniform_temperature(x) result(T)
-    real(dp), intent(in) :: x(:)
-    real(dp) :: T(size(x))
-    T = 1.0_dp
-  end function uniform_temperature
+  real(dp) function T0()
+    T0 = 1.0_dp
+  end function T0
 
+  !> Gaussian density perturbation centred at x = 0.5.
   pure function gaussian_rho(x) result(rho1)
     real(dp), intent(in) :: x(:)
     real(dp) :: rho1(size(x))
@@ -102,22 +125,33 @@ contains
     rho1 = exp(-((x - x0) / sigma)**2)
   end function gaussian_rho
 
+  !> Derivative of the Gaussian density perturbation.
+  pure function gaussian_drho(x) result(drho1)
+    real(dp), intent(in) :: x(:)
+    real(dp) :: drho1(size(x))
+    real(dp), parameter :: x0 = 0.5_dp, sigma = 0.05_dp
+    drho1 = -2.0_dp * (x - x0) / sigma**2 * exp(-((x - x0) / sigma)**2)
+  end function gaussian_drho
+
 end submodule smod_user_defined
 ```
 
-The setter routines available on the `initial_conditions` object are:
+The setter routines available on the `iv_initial_conditions` object are:
 
-| Subroutine | Component |
-|---|---|
-| `set_ic_density_funcs(rho_func [, drho_func])` | $\rho_1$ |
-| `set_ic_velocity_1_funcs(v01_func, dv01_func)` | $v_1$ |
-| `set_ic_velocity_2_funcs(v02_func, dv02_func)` | $v_2$ |
-| `set_ic_velocity_3_funcs(v03_func, dv03_func)` | $v_3$ |
-| `set_ic_temperature_funcs(T_func [, dT_func])` | $T_1$ |
+| Subroutine | Component | Physics types |
+|---|---|---|
+| `set_ic_density_funcs(rho_func [, drho_func])` | $\rho_1$ | all |
+| `set_ic_velocity_1_funcs(v01_func, dv01_func)` | $v_1$ | all |
+| `set_ic_velocity_2_funcs(v02_func, dv02_func)` | $v_2$ | `hd`, `mhd` |
+| `set_ic_velocity_3_funcs(v03_func, dv03_func)` | $v_3$ | `hd`, `mhd` |
+| `set_ic_temperature_funcs(T_func [, dT_func])` | $T_1$ | `hd-1d`, `hd`, `mhd` |
+| `set_ic_a1_funcs(a1_func [, da1_func])` | $a_1$ | `mhd` |
+| `set_ic_a2_funcs(a2_func, da2_func)` | $a_2$ | `mhd` |
+| `set_ic_a3_funcs(a3_func, da3_func)` | $a_3$ | `mhd` |
 
 Components not set default to zero. Components not present in the chosen physics type are silently ignored.
-It is not necessary to set the density or temperature derivatives when using the default basis functions, therefore
-arguments are optional.
+The derivative argument is optional for components that use a quadratic basis function by default
+($\rho_1$, $v_2$, $v_3$, $T_1$, $a_1$) and required for those that use a cubic one ($v_1$, $a_2$, $a_3$).
 
 ## Post-processing with Pylbo
 

--- a/docs/general/solvers.md
+++ b/docs/general/solvers.md
@@ -30,6 +30,23 @@ near the interesting regions. Comparing the eigenvalues between both solution st
 {: .notice--success}
 
 
+## No solver
+The eigenvalue solve can be bypassed entirely by selecting the `"none"` solver:
+```fortran
+&solvelist
+  solver = "none"
+/
+```
+The matrices are still assembled, but no eigenvalue solver is called and the eigenvalue array in
+the datfile is left empty. Eigenfunction, eigenvector and residual output is switched off
+automatically, since these are meaningless without eigenvalues.
+
+This is useful for a dry run (for example to assemble and write the matrices with
+`write_matrices = .true.`), and for [initial-value runs](../../general/initial_value), which reuse
+the assembled `A` and `B` matrices but do not need the eigenvalues. Initial-value snapshot output
+is unaffected by this setting.
+
+
 ## QR-invert
 This is the default solver that Legolas uses, which transforms the general eigenvalue problem into a standard one:
 

--- a/src/dataIO/mod_input.f08
+++ b/src/dataIO/mod_input.f08
@@ -48,7 +48,7 @@ contains
 
     ! make sure to update dimensions after reading in the parfile
     call settings%update_block_dimensions()
-    if (settings%solvers%get_solver() == "none") call settings%io%set_all_io_to_false()
+    if (settings%solvers%get_solver() == "none") call settings%io%disable_evp_output()
   end subroutine read_parfile
 
 

--- a/src/initial_value/mod_iv_initial_conditions.f08
+++ b/src/initial_value/mod_iv_initial_conditions.f08
@@ -20,19 +20,30 @@ module mod_iv_initial_conditions
       procedure(profile_fcn), pointer, nopass :: T   => null()
       procedure(profile_fcn), pointer, nopass :: dT  => null()
     end type ic_temperature_t
-  
+
+    type, public :: ic_magnetic_t
+      procedure(profile_fcn), pointer, nopass :: a   => null()
+      procedure(profile_fcn), pointer, nopass :: da  => null()
+    end type ic_magnetic_t
+
     type, public :: initial_conditions_t
       type(ic_density_t)     :: density
       type(ic_velocity_t)    :: velocity_1
       type(ic_velocity_t)    :: velocity_2
       type(ic_velocity_t)    :: velocity_3
       type(ic_temperature_t) :: temperature
+      type(ic_magnetic_t)    :: magnetic_1
+      type(ic_magnetic_t)    :: magnetic_2
+      type(ic_magnetic_t)    :: magnetic_3
     contains
       procedure :: set_ic_density_funcs
       procedure :: set_ic_velocity_1_funcs
       procedure :: set_ic_velocity_2_funcs
       procedure :: set_ic_velocity_3_funcs
       procedure :: set_ic_temperature_funcs
+      procedure :: set_ic_a1_funcs
+      procedure :: set_ic_a2_funcs
+      procedure :: set_ic_a3_funcs
     end type initial_conditions_t
 
     public :: new_initial_conditions
@@ -60,6 +71,15 @@ module mod_iv_initial_conditions
 
       ic%temperature%T  => zero_fcn
       ic%temperature%dT => zero_fcn
+
+      ic%magnetic_1%a  => zero_fcn
+      ic%magnetic_1%da => zero_fcn
+
+      ic%magnetic_2%a  => zero_fcn
+      ic%magnetic_2%da => zero_fcn
+
+      ic%magnetic_3%a  => zero_fcn
+      ic%magnetic_3%da => zero_fcn
 
     end function new_initial_conditions
   
@@ -116,6 +136,39 @@ module mod_iv_initial_conditions
       self%temperature%T => T_func
       if (present(dT_func)) self%temperature%dT => dT_func
     end subroutine set_ic_temperature_funcs
-  
+
+    ! a1 defaults to a quadratic basis function, so its derivative is optional.
+    subroutine set_ic_a1_funcs(self, a1_func, da1_func)
+      class(initial_conditions_t), intent(inout) :: self
+      procedure(profile_fcn) :: a1_func
+      procedure(profile_fcn), optional :: da1_func
+
+      call logger%debug("Setting ICs for component a1.")
+      self%magnetic_1%a => a1_func
+      if (present(da1_func)) self%magnetic_1%da => da1_func
+    end subroutine set_ic_a1_funcs
+
+    ! a2 defaults to a cubic basis function, so its derivative is required.
+    subroutine set_ic_a2_funcs(self, a2_func, da2_func)
+      class(initial_conditions_t), intent(inout) :: self
+      procedure(profile_fcn) :: a2_func
+      procedure(profile_fcn) :: da2_func
+
+      call logger%debug("Setting ICs for component a2.")
+      self%magnetic_2%a => a2_func
+      self%magnetic_2%da => da2_func
+    end subroutine set_ic_a2_funcs
+
+    ! a3 defaults to a cubic basis function, so its derivative is required.
+    subroutine set_ic_a3_funcs(self, a3_func, da3_func)
+      class(initial_conditions_t), intent(inout) :: self
+      procedure(profile_fcn) :: a3_func
+      procedure(profile_fcn) :: da3_func
+
+      call logger%debug("Setting ICs for component a3.")
+      self%magnetic_3%a => a3_func
+      self%magnetic_3%da => da3_func
+    end subroutine set_ic_a3_funcs
+
   end module mod_iv_initial_conditions
   

--- a/src/initial_value/mod_iv_solver.f08
+++ b/src/initial_value/mod_iv_solver.f08
@@ -10,7 +10,8 @@ module mod_iv_solver
 
   use mod_banded_matrix, only: banded_matrix_t, new_banded_matrix
   use mod_banded_operations, only: banded_copy, constant_times_banded_plus_banded
-  use mod_linear_systems, only: solve_linear_system_complex_banded
+  use mod_linear_systems, only: solve_linear_system_complex_banded_LU, &
+    get_LU_factorisation_banded
   use mod_transform_matrix, only: matrix_to_banded
   implicit none
 
@@ -38,6 +39,8 @@ contains
     complex(dp) :: beta, gamma
     complex(dp), allocatable :: z(:)    ! intermediate result
     complex(dp), allocatable :: rhs(:)
+    complex(dp), allocatable :: M_LU(:, :)  ! pre-factorised M (reused each step)
+    integer, allocatable :: M_ipiv(:)
     integer :: n                        ! dimension of matrices and x
     integer :: i
 
@@ -115,6 +118,9 @@ contains
     gamma = -dt * alpha
     call constant_times_banded_plus_banded(M, A, gamma)
 
+    ! 3. Pre-factorise M once
+    call get_LU_factorisation_banded(M, M_LU, M_ipiv)
+
     do i = 1, num_steps
       ! rhs = (B + beta * A)x = Bx + beta * Ax
       ! compute as 3 banded level 2 BLAS operations
@@ -129,8 +135,8 @@ contains
       ! 3. compute rhs = rhs + beta*z
       call zaxpy(n, beta, z, 1, rhs, 1)
 
-      ! Solve resulting banded system with zgbsv
-      x = solve_linear_system_complex_banded(M, rhs)
+      ! Solve using pre-factorised LU (avoids re-factorising the constant M each step)
+      x = solve_linear_system_complex_banded_LU(M, rhs, M_LU, M_ipiv)
 
       ! Save in history
       if (present(snapshots)) then
@@ -152,6 +158,8 @@ contains
 
     deallocate(rhs)
     deallocate(z)
+    deallocate(M_LU)
+    deallocate(M_ipiv)
 
   end subroutine solve
 

--- a/src/initial_value/mod_iv_state_vector.f08
+++ b/src/initial_value/mod_iv_state_vector.f08
@@ -106,9 +106,24 @@ module mod_iv_state_vector
       self%components(3)%ptr => iv_v2
       self%components(4)%ptr => iv_v3
       self%components(5)%ptr => iv_T1
-  
+
+    case("mhd")
+      self%num_components = 8
+      allocate(self%components(self%num_components))
+      self%components(1)%ptr => iv_rho1
+      self%components(2)%ptr => iv_v1
+      self%components(3)%ptr => iv_v2
+      self%components(4)%ptr => iv_v3
+      self%components(5)%ptr => iv_T1
+      self%components(6)%ptr => iv_a1
+      self%components(7)%ptr => iv_a2
+      self%components(8)%ptr => iv_a3
+
     case default
-      call logger%error("Physics type not implemented for IVP mode.")
+      call logger%error( &
+        "IV state vector: unsupported physics type '" // physics_type // "'" &
+      )
+      return
     end select
   
     self%stride = 2 * self%num_components

--- a/src/initial_value/mod_iv_state_vector.f08
+++ b/src/initial_value/mod_iv_state_vector.f08
@@ -156,7 +156,19 @@ module mod_iv_state_vector
       case("T")
         fcn  => initial_conditions%temperature%T
         dfcn => initial_conditions%temperature%dT
-  
+
+      case("a1")
+         fcn  => initial_conditions%magnetic_1%a
+         dfcn => initial_conditions%magnetic_1%da
+
+      case("a2")
+         fcn  => initial_conditions%magnetic_2%a
+         dfcn => initial_conditions%magnetic_2%da
+
+      case("a3")
+         fcn  => initial_conditions%magnetic_3%a
+         dfcn => initial_conditions%magnetic_3%da
+
       case default
          ! If no match, assume 0
          fcn  => zero_fcn

--- a/src/main.f08
+++ b/src/main.f08
@@ -87,12 +87,18 @@ program legolas
     call logger%info("done.")
   end if
 
-  call logger%info("solving eigenvalue problem...")
-  call timer%start_timer()
-  call do_eigenvalue_problem_allocations()
-  call solve_evp(matrix_A, matrix_B, settings, omega, right_eigenvectors)
-  timer%evp_time = timer%end_timer()
-  call logger%info("done.")
+  if (settings%solvers%get_solver() == "none") then
+    call logger%info("skipping eigenvalue problem (solver = 'none')")
+    allocate(omega(0))
+    allocate(right_eigenvectors(2, 2))
+  else
+    call logger%info("solving eigenvalue problem...")
+    call timer%start_timer()
+    call do_eigenvalue_problem_allocations()
+    call solve_evp(matrix_A, matrix_B, settings, omega, right_eigenvectors)
+    timer%evp_time = timer%end_timer()
+    call logger%info("done.")
+  end if
 
   call timer%start_timer()
   eigenfunctions = new_eigenfunctions(settings, grid, background)

--- a/src/settings/mod_io_settings.f08
+++ b/src/settings/mod_io_settings.f08
@@ -27,7 +27,7 @@ module mod_io_settings
     procedure, public :: set_output_folder
     procedure, public :: get_output_folder
     procedure, public :: should_compute_eigenvectors
-    procedure, public :: set_all_io_to_false
+    procedure, public :: disable_evp_output
     procedure, public :: delete
   end type io_settings_t
 
@@ -95,14 +95,13 @@ contains
   end function should_compute_eigenvectors
 
 
-  pure subroutine set_all_io_to_false(this)
+  pure subroutine disable_evp_output(this)
     class(io_settings_t), intent(inout) :: this
     this%write_eigenvectors = .false.
     this%write_residuals = .false.
     this%write_eigenfunctions = .false.
     this%write_derived_eigenfunctions = .false.
-    this%write_iv_snapshots = .false.
-  end subroutine set_all_io_to_false
+  end subroutine disable_evp_output
 
 
   pure subroutine delete(this)


### PR DESCRIPTION
## PR description
Some improvements for the IVP solver for the new Legolas release.

## New features
**Legolas**
- Added `skip_evp` option to skip the eigenvalue solve and do IVP simulation only.
- Optimisation in the IVP timestepping algorithm.
- IVP solver now supports all physics subsystems (including MHD).
- Updated IVP documentation

**Pylbo**
- Pylbo now reads the `skip_evp` boolean flag

## Bugfixes
**Legolas**
- None

**Pylbo**
- None
## Checklist
- [x] all tests pass (and for new features, new tests are added)
- [x] documentation has been updated (if applicable)
